### PR TITLE
Fix volleyball purge: use כדורעף: namespace for opponent pages

### DIFF
--- a/src/maccabipediabot/volleyball/gamesbot_volleyball.py
+++ b/src/maccabipediabot/volleyball/gamesbot_volleyball.py
@@ -183,7 +183,7 @@ def collect_related_pages_from_game(game: VolleyballGame) -> set[str]:
     """Collect all pages that should be purged after this volleyball game is uploaded."""
     pages_to_purge = set()
 
-    pages_to_purge.add(game.opponent)
+    pages_to_purge.add(f"{volleyball_games_prefix}:{game.opponent}")
 
     if game.season:
         pages_to_purge.add(f"כדורעף:עונת {game.season}")


### PR DESCRIPTION
## Summary
- Opponent pages in MaccabiPedia live under the `כדורעף:` namespace, not the main namespace
- The purge was using `game.opponent` (plain name), causing all 10 opponent purges to be wrong:
  - 7 opponents were silently skipped (page not found in main namespace)
  - 3 opponents were accidentally purging unrelated **football** pages (e.g. `הפועל ירושלים` in main namespace is a football page)
- Fix: use `f"{volleyball_games_prefix}:{game.opponent}"` — same pattern already used for season and competition pages

## Verified from GitHub Actions logs
Run `23399393968`: 18 out of 24 pages were skipped, including all 10 opponents. The 3 that did "purge" were confirmed to be football pages via wiki API.

## Test plan
- [ ] Trigger a volleyball upload run and confirm opponent pages now appear in the "Purging:" log lines instead of "Page doesn't exist, skipping:"

🤖 Generated with [Claude Code](https://claude.com/claude-code)