### PR TITLE
docs: add basketball posters template and filename convention

### DIFF
--- a/.claude/maccabipedia_structure_knowledge.md
+++ b/.claude/maccabipedia_structure_knowledge.md
@@ -61,10 +61,7 @@ Prefer Cargo over scraping wiki text.
 Hebrew redirect syntax: `#הפניה [[Target_Page_Name]]`
 - Basketball seasons: canonical = `כדורסל:עונת YYYY/YY`, redirect from `כדורסל:YYYY/YY`.
 
-## 7. Non-Game Entities
-
-**Newspapers** (`File:` pages, template `{{תיוג עיתונים}}`):
-- File naming: `{שם_עיתון}_{תאריך_המשחק}_{שם_היריבה}_{מספר}_{(תאריך_פרסום)}`
+## 7. Game Media Files
 
 **Tickets** (`File:` pages):
 - Basketball: `{{תיוג כרטיס משחק כדורסל|משחק=PAGE_NAME}}`
@@ -73,6 +70,11 @@ Hebrew redirect syntax: `#הפניה [[Target_Page_Name]]`
 - Basketball: `{{תיוג כרזת כדורסל|משחק=PAGE_NAME}}`
 - If no matching game page found in Cargo, upload with `{{תיוג כרזת כדורסל}}` (no `משחק=`) for tracking
 - Filename convention: `כרזת משחק כדורסל DD-MM-YYYY.jpg`
+
+**Newspapers** (`File:` pages, template `{{תיוג עיתונים}}`):
+- File naming: `{שם_עיתון}_{תאריך_המשחק}_{שם_היריבה}_{מספר}_{(תאריך_פרסום)}`
+
+## 8. Non-Game Entities
 
 **Fan Songs** (`שיר:` namespace, template `{{שיר}}`):
 - Parameters: `קטגוריה`, `שם השיר`, `עונת בכורה`, `על השיר`, `ביצוע לשיר`, `מילים`

--- a/.claude/maccabipedia_structure_knowledge.md
+++ b/.claude/maccabipedia_structure_knowledge.md
@@ -67,7 +67,12 @@ Hebrew redirect syntax: `#הפניה [[Target_Page_Name]]`
 - File naming: `{שם_עיתון}_{תאריך_המשחק}_{שם_היריבה}_{מספר}_{(תאריך_פרסום)}`
 
 **Tickets** (`File:` pages):
-- Basketball: `{{תיוג משחק כדורסל|שם משחק=PAGE_NAME}}`
+- Basketball: `{{תיוג כרטיס משחק כדורסל|משחק=PAGE_NAME}}`
+
+**Posters** (`File:` pages):
+- Basketball: `{{תיוג כרזת כדורסל|משחק=PAGE_NAME}}`
+- If no matching game page found in Cargo, upload with `{{תיוג כרזת כדורסל}}` (no `משחק=`) for tracking
+- Filename convention: `כרזת משחק כדורסל DD-MM-YYYY.jpg`
 
 **Fan Songs** (`שיר:` namespace, template `{{שיר}}`):
 - Parameters: `קטגוריה`, `שם השיר`, `עונת בכורה`, `על השיר`, `ביצוע לשיר`, `מילים`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 - GitHub CLI is available as `gh.exe` (not `gh`) in WSL.
 
 ## 3. Git Hygiene
-- **Always work on a feature branch.** Before making any code changes, check the current branch. If on `master`, create a feature branch first.
+- **Always work on a feature branch.** Before making any changes — code, docs, or `.claude/` files — check the current branch. If on `master`, create a feature branch first. Nothing is committed directly to `master`; everything goes through a PR.
 - Before any `git add`, run `git status` and review every file. Only stage files directly related to the current task.
 - At the end of every task involving a git branch, switch back to `master` and confirm the branch is clean.
 


### PR DESCRIPTION
## Summary
- Adds poster template `{{תיוג כרזת כדורסל|משחק=PAGE_NAME}}` to structure knowledge
- Documents fallback behavior (no `משחק=`) when no game page is found
- Documents filename convention: `כרזת משחק כדורסל DD-MM-YYYY.jpg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)