### PR TITLE
docs: trim CLAUDE.md to reduce token usage per session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 - Before any `git add`, run `git status` and review every file. Only stage files directly related to the current task.
 - At the end of every task involving a git branch, switch back to `master` and confirm the branch is clean.
 
-## 6. Lessons Learned (CRITICAL — read every session)
+## 6. Lessons Learned
 
 ### Always validate API responses before parsing
 Cargo Export returns HTML error pages on internal errors — not JSON. Always check `response.status_code == 200` and `'application/json' in response.headers.get('Content-Type', '')` before calling `.json()`. Log the raw response on failure.
@@ -30,31 +30,17 @@ When implementing a feature for volleyball/basketball, always inspect the equiva
 ### Hebrew files opened in Windows apps need UTF-8 BOM
 Use `utf-8-sig` encoding when writing CSV/TXT/JSON files with Hebrew text that may be opened in Excel or other Windows apps.
 
-### Unrelated files must not be staged in commits
-Files created during experimentation must be cleaned up before staging. Never use `git add .` blindly.
-
-### Switch back to `master` after finishing a feature
-After completing and merging a task, always `git checkout master` and confirm the branch is clean.
-
 ### Never use pywikibot's file_page.upload() — use requests directly
-pywikibot's MIME multipart builder (based on Python's `email.mime` library) produces malformed HTTP requests:
-- Adds `MIME-Version: 1.0` to every body part (email header, invalid in HTTP)
-- Uses LF-only `\n` line endings instead of CRLF `\r\n` (required by RFC 2046)
-
-Apache returns 400 Bad Request. Use `requests.post(..., files={'file': ('FAKE-NAME', data, mime_type)})` with cookies and CSRF token from pywikibot's session instead. See `upload_basketball_tickets.py` → `_upload_file_via_requests()` for the reference implementation.
+Produces malformed HTTP (bad MIME headers, LF-only line endings) → Apache 400. Use `requests.post(..., files=...)` with pywikibot session cookies. Reference: `upload_basketball_tickets.py` → `_upload_file_via_requests()`.
 
 ### Running scripts requires MACCABIPEDIA_UA_SCRIPT env var
-Scripts that upload to Maccabipedia must set the user-agent to a whitelisted script name via:
-```
-source ~/.secrets && MACCABIPEDIA_UA_SCRIPT=gamesbot_basketball python script.py
-```
-The server's ModSecurity WAF blocks requests from unknown user-agent script names.
+ModSecurity WAF blocks unknown user-agent script names. Always: `source ~/.secrets && MACCABIPEDIA_UA_SCRIPT=<name> python script.py`
 
 ---
 
-## 7. MaccabiPedia Structure (CRITICAL — read every session)
+## 7. MaccabiPedia Structure
 
-Always read `.claude/maccabipedia_structure_knowledge.md` before working with game pages, player pages, templates, or the Cargo API.
+Read `.claude/maccabipedia_structure_knowledge.md` when working with game pages, player pages, templates, or the Cargo API.
 
 ## 8. Research Sources (read when searching for external data)
 


### PR DESCRIPTION
## Summary
- Remove misleading "CRITICAL — read every session" labels that caused structure knowledge file (~1200 tokens) to be read unnecessarily
- Drop two lessons already covered in the Git Hygiene section (redundant)
- Condense verbose pywikibot and UA_SCRIPT lessons to one-liners (~200 chars saved)

## Estimated savings
~600 tokens on every CLAUDE.md load + ~1200 tokens avoided on sessions not involving game/player pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)