### PR TITLE
feat: pill-style navigation bars for player achievement category pages

### DIFF
--- a/.github/workflows/add_player_category_navbars.yaml
+++ b/.github/workflows/add_player_category_navbars.yaml
@@ -1,0 +1,30 @@
+name: Add player category navigation bars
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  add-player-category-navbars:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+          architecture: x64
+      - name: Install dependencies
+        run: pip install -e .
+      - name: Add pill navigation bars to player achievement category pages
+        env:
+          PYWIKIBOT_DIR: src/maccabipediabot/pywikibot_configs/
+          MACCABIPEDIA_BOT_USERNAME: ${{ secrets.MACCABIPEDIA_BOT_USERNAME }}
+          MACCABIPEDIA_BOT_PASSWORD: ${{ secrets.MACCABIPEDIA_BOT_PASSWORD }}
+        run: python -m maccabipediabot.maintenance.football.add_player_category_navbars --live
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/src/maccabipediabot/maintenance/football/add_player_category_navbars.py
+++ b/src/maccabipediabot/maintenance/football/add_player_category_navbars.py
@@ -1,7 +1,7 @@
 """
-Add pill-style navigation bars to football player achievement category pages.
+Add pill-style navigation bars to player achievement category pages.
 
-For each competition-type series (e.g. "שחקני כדורגל שזכו ב-N אליפויות"),
+For each sport and competition-type series (e.g. "שחקני כדורגל שזכו ב-N אליפויות"),
 this script:
   1. Discovers all existing numbered categories via the MediaWiki API.
   2. Creates (or updates) one navigation template per competition type,
@@ -16,6 +16,9 @@ Usage:
     # Live run:
     python -m maccabipediabot.maintenance.football.add_player_category_navbars --live
 
+    # Single sport:
+    python -m maccabipediabot.maintenance.football.add_player_category_navbars --live --sport כדורגל
+
 Dependencies: pywikibot (configured for maccabipedia)
 """
 
@@ -23,6 +26,7 @@ import argparse
 import logging
 import re
 from collections import defaultdict
+from dataclasses import dataclass
 
 import pywikibot
 
@@ -31,42 +35,63 @@ from maccabipediabot.common.wiki_login import get_site
 logging.basicConfig(format="%(asctime)s : %(levelname)s : %(message)s", level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-CATEGORY_PREFIX = "שחקני כדורגל שזכו ב-"
-TEMPLATE_PREFIX = "ניווט שחקני כדורגל - "
-
-# Human-readable labels shown above the pill row, keyed by the Hebrew type suffix
-# (exact string that follows "ב-N " in the category name).
-TYPE_LABELS = {
-    "אליפויות":               "זכיות באליפות:",
-    "אלוף האלופים":           "זכיות באלוף האלופים:",
-    "אלוף האליפיים":          "זכיות באלוף האלופים:",
-    "גביעי מדינה":            "זכיות בגביע המדינה:",
-    "גביעי טוטו":             "זכיות בגביע הטוטו:",
-    "גביעי ליליאן":           "זכיות בגביע ליליאן:",
-    "גביעי אסיה לאלופות":     "זכיות בגביע אסיה לאלופות:",
-    "תאריים":                 "סך כל התארים:",
-}
-
 # CSS classes defined in MediaWiki:Common.css
 _PILL_CLASS = "nmpAchievementsNavPill"
 _PILL_ACTIVE_CLASS = "nmpAchievementsNavPillActive"
 
 
-def discover_categories(site: pywikibot.Site) -> dict[str, list[int]]:
+@dataclass
+class SportConfig:
+    name: str           # e.g. "כדורגל"
+    category_prefix: str  # prefix for allcategories query
+    template_prefix: str  # prefix for template titles
+    type_labels: dict[str, str]  # type_name -> label shown above pills
+
+
+SPORTS = [
+    SportConfig(
+        name="כדורגל",
+        category_prefix="שחקני כדורגל שזכו ב-",
+        template_prefix="ניווט שחקני כדורגל - ",
+        type_labels={
+            "אליפויות":             "זכיות באליפות:",
+            "אלוף האלופים":         "זכיות באלוף האלופים:",
+            "אלוף האליפיים":        "זכיות באלוף האלופים:",
+            "גביעי מדינה":          "זכיות בגביע המדינה:",
+            "גביעי טוטו":           "זכיות בגביע הטוטו:",
+            "גביעי ליליאן":         "זכיות בגביע ליליאן:",
+            "גביעי אסיה לאלופות":   "זכיות בגביע אסיה לאלופות:",
+            "תאריים":               "סך כל התארים:",
+        },
+    ),
+    SportConfig(
+        name="כדורעף",
+        category_prefix="שחקני כדורעף שזכו ב-",
+        template_prefix="ניווט שחקני כדורעף - ",
+        type_labels={
+            "אליפויות":     "זכיות באליפות:",
+            "גביעי אטקין":  "זכיות בגביע אטקין:",
+            "גביעי מדינה":  "זכיות בגביע המדינה:",
+            "תאריים":       "סך כל התארים:",
+            "תארים":        "סך כל התארים:",
+        },
+    ),
+]
+
+
+def discover_categories(site: pywikibot.Site, sport: SportConfig) -> dict[str, list[int]]:
     """
-    Query the wiki API for all categories starting with CATEGORY_PREFIX.
+    Query the wiki for all categories matching this sport's prefix.
     Returns a dict mapping type_name -> sorted list of numbers.
-    e.g. {"אליפויות": [1,2,3,4,5,6,7], "תאריים": [1,2,...,17], ...}
     """
-    logger.info("Querying wiki for all player-achievement categories...")
+    logger.info(f"[{sport.name}] Querying categories with prefix: {sport.category_prefix!r}")
     raw_cats = [
         cat.title(with_ns=False)
-        for cat in site.allcategories(prefix=CATEGORY_PREFIX)
+        for cat in site.allcategories(prefix=sport.category_prefix)
     ]
-    logger.info(f"Found {len(raw_cats)} matching categories")
+    logger.info(f"[{sport.name}] Found {len(raw_cats)} matching categories")
 
-    # Pattern: "שחקני כדורגל שזכו ב-{N} {TYPE}"
-    pattern = re.compile(r"^שחקני כדורגל שזכו ב-(\d+) (.+)$")
+    pattern = re.compile(r"^.+שזכו ב-(\d+) (.+)$")
     grouped: dict[str, list[int]] = defaultdict(list)
     for cat in raw_cats:
         m = pattern.match(cat)
@@ -79,18 +104,15 @@ def discover_categories(site: pywikibot.Site) -> dict[str, list[int]]:
     return {t: sorted(ns) for t, ns in grouped.items()}
 
 
-def build_template_wikitext(type_name: str, label: str, numbers: list[int]) -> str:
-    """
-    Build the full wikitext for a pill-navigation template.
-    The template takes one positional parameter {{{1}}}: the current number.
-    """
+def build_template_wikitext(
+    sport: SportConfig, type_name: str, label: str, numbers: list[int]
+) -> str:
+    """Build the full wikitext for a pill-navigation template."""
     pills = []
     for n in numbers:
-        cat_full = f"קטגוריה:שחקני כדורגל שזכו ב-{n} {type_name}"
+        cat_full = f"קטגוריה:{sport.category_prefix}{n} {type_name}"
         current_html = f'<span class="{_PILL_ACTIVE_CLASS}">{n}</span>'
         linked_html = f'[[:{ cat_full }|<span class="{_PILL_CLASS}">{n}</span>]]'
-        # Use string concatenation to avoid f-string brace-escaping issues with
-        # MediaWiki's {{{1}}} parameter syntax and {{#ifeq:...}} parser function.
         pill = "{{#ifeq:{{{1}}}|" + str(n) + "|" + current_html + "|" + linked_html + "}}"
         pills.append(pill)
 
@@ -112,14 +134,15 @@ def build_template_wikitext(type_name: str, label: str, numbers: list[int]) -> s
 
 def create_or_update_template(
     site: pywikibot.Site,
+    sport: SportConfig,
     type_name: str,
     label: str,
     numbers: list[int],
     dry_run: bool,
 ) -> None:
-    template_title = f"תבנית:{TEMPLATE_PREFIX}{type_name}"
+    template_title = f"תבנית:{sport.template_prefix}{type_name}"
     page = pywikibot.Page(site, template_title)
-    new_content = build_template_wikitext(type_name, label, numbers)
+    new_content = build_template_wikitext(sport, type_name, label, numbers)
 
     if page.exists() and page.text == new_content:
         logger.info(f"Template already up-to-date: {template_title}")
@@ -132,17 +155,18 @@ def create_or_update_template(
         return
 
     page.text = new_content
-    page.save(summary="בוט: הוספת תבנית ניווט לקטגוריות שחקני כדורגל לפי הישגים", minor=False)
+    page.save(summary="בוט: הוספת תבנית ניווט לקטגוריות שחקנים לפי הישגים", minor=False)
 
 
 def add_navbar_to_category_page(
     site: pywikibot.Site,
+    sport: SportConfig,
     type_name: str,
     n: int,
     dry_run: bool,
 ) -> None:
-    template_call = f"{{{{{TEMPLATE_PREFIX}{type_name}|{n}}}}}"
-    cat_title = f"קטגוריה:שחקני כדורגל שזכו ב-{n} {type_name}"
+    template_call = f"{{{{{sport.template_prefix}{type_name}|{n}}}}}"
+    cat_title = f"קטגוריה:{sport.category_prefix}{n} {type_name}"
     page = pywikibot.Page(site, cat_title)
 
     existing = page.text  # '' for category pages with no explicit wikitext
@@ -162,23 +186,35 @@ def add_navbar_to_category_page(
     page.save(summary="בוט: הוספת ניווט לקטגוריה", minor=True)
 
 
-def main(dry_run: bool = True, test: bool = False) -> None:
-    site = get_site()
-
-    type_map = discover_categories(site)
-    logger.info(f"Competition types found: {list(type_map.keys())}")
+def process_sport(
+    site: pywikibot.Site, sport: SportConfig, dry_run: bool, test: bool
+) -> None:
+    type_map = discover_categories(site, sport)
+    logger.info(f"[{sport.name}] Types found: {list(type_map.keys())}")
 
     for type_name, numbers in sorted(type_map.items()):
-        label = TYPE_LABELS.get(type_name, f"שחקני כדורגל לפי מספר {type_name}")
-        logger.info(f"\n--- {type_name} ({numbers}) ---")
+        label = sport.type_labels.get(type_name, f"זכיות ב{type_name}:")
+        logger.info(f"\n--- [{sport.name}] {type_name} ({numbers}) ---")
 
-        create_or_update_template(site, type_name, label, numbers, dry_run)
+        create_or_update_template(site, sport, type_name, label, numbers, dry_run)
 
         for n in numbers:
-            add_navbar_to_category_page(site, type_name, n, dry_run)
+            add_navbar_to_category_page(site, sport, type_name, n, dry_run)
             if test:
                 logger.info("Test mode: stopping after first page.")
                 return
+
+
+def main(dry_run: bool = True, test: bool = False, sport_filter: str | None = None) -> None:
+    site = get_site()
+
+    sports = [s for s in SPORTS if sport_filter is None or s.name == sport_filter]
+    if not sports:
+        logger.error(f"Unknown sport: {sport_filter!r}. Available: {[s.name for s in SPORTS]}")
+        return
+
+    for sport in sports:
+        process_sport(site, sport, dry_run, test)
 
     logger.info("\nDone.")
 
@@ -187,5 +223,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--live", action="store_true", help="Actually edit the wiki (default: dry-run)")
     parser.add_argument("--test", action="store_true", help="Only process one template and one category page")
+    parser.add_argument("--sport", help="Only process this sport (e.g. כדורגל, כדורעף)")
     args = parser.parse_args()
-    main(dry_run=not args.live, test=args.test)
+    main(dry_run=not args.live, test=args.test, sport_filter=args.sport)

--- a/src/maccabipediabot/maintenance/football/add_player_category_navbars.py
+++ b/src/maccabipediabot/maintenance/football/add_player_category_navbars.py
@@ -215,8 +215,15 @@ def main(dry_run: bool = True, test: bool = False, sport_filter: str | None = No
     site = get_site()
     all_series = discover_all_series(site, sport_filter=sport_filter)
 
+    unknown_types: list[str] = []
+
     for series in sorted(all_series, key=lambda s: (s.sport, s.type_name)):
-        label = TYPE_LABELS.get(series.type_name, f"{series.type_name}:")
+        if series.type_name not in TYPE_LABELS:
+            unknown_types.append(f"  [{series.sport}] {series.type_name!r} — e.g. {series.cat_title(series.numbers[0])}")
+            logger.warning(f"Unknown type_name {series.type_name!r} for sport {series.sport!r} — skipping (add to TYPE_LABELS)")
+            continue
+
+        label = TYPE_LABELS[series.type_name]
         logger.info(f"\n--- [{series.sport}] {series.type_name} ({series.numbers}) ---")
 
         create_or_update_template(site, series, label, dry_run)
@@ -226,6 +233,12 @@ def main(dry_run: bool = True, test: bool = False, sport_filter: str | None = No
             if test:
                 logger.info("Test mode: stopping after first page.")
                 return
+
+    if unknown_types:
+        raise ValueError(
+            "New competition type(s) found — add them to TYPE_LABELS with a human-readable label:\n"
+            + "\n".join(unknown_types)
+        )
 
     logger.info("\nDone.")
 

--- a/src/maccabipediabot/maintenance/football/add_player_category_navbars.py
+++ b/src/maccabipediabot/maintenance/football/add_player_category_navbars.py
@@ -1,0 +1,191 @@
+"""
+Add pill-style navigation bars to football player achievement category pages.
+
+For each competition-type series (e.g. "שחקני כדורגל שזכו ב-N אליפויות"),
+this script:
+  1. Discovers all existing numbered categories via the MediaWiki API.
+  2. Creates (or updates) one navigation template per competition type,
+     e.g. "תבנית:ניווט שחקני כדורגל - אליפויות".
+  3. Edits each category page to prepend the template call so the nav bar
+     appears above the member list.
+
+Usage:
+    # Dry-run (prints what would change, makes no edits):
+    python -m maccabipediabot.maintenance.football.add_player_category_navbars
+
+    # Live run:
+    python -m maccabipediabot.maintenance.football.add_player_category_navbars --live
+
+Dependencies: pywikibot (configured for maccabipedia)
+"""
+
+import argparse
+import logging
+import re
+from collections import defaultdict
+
+import pywikibot
+
+from maccabipediabot.common.wiki_login import get_site
+
+logging.basicConfig(format="%(asctime)s : %(levelname)s : %(message)s", level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+CATEGORY_PREFIX = "שחקני כדורגל שזכו ב-"
+TEMPLATE_PREFIX = "ניווט שחקני כדורגל - "
+
+# Human-readable labels shown above the pill row, keyed by the Hebrew type suffix
+# (exact string that follows "ב-N " in the category name).
+TYPE_LABELS = {
+    "אליפויות":               "זכיות באליפות:",
+    "אלוף האלופים":           "זכיות באלוף האלופים:",
+    "אלוף האליפיים":          "זכיות באלוף האלופים:",
+    "גביעי מדינה":            "זכיות בגביע המדינה:",
+    "גביעי טוטו":             "זכיות בגביע הטוטו:",
+    "גביעי ליליאן":           "זכיות בגביע ליליאן:",
+    "גביעי אסיה לאלופות":     "זכיות בגביע אסיה לאלופות:",
+    "תאריים":                 "סך כל התארים:",
+}
+
+# CSS classes defined in MediaWiki:Common.css
+_PILL_CLASS = "nmpAchievementsNavPill"
+_PILL_ACTIVE_CLASS = "nmpAchievementsNavPillActive"
+
+
+def discover_categories(site: pywikibot.Site) -> dict[str, list[int]]:
+    """
+    Query the wiki API for all categories starting with CATEGORY_PREFIX.
+    Returns a dict mapping type_name -> sorted list of numbers.
+    e.g. {"אליפויות": [1,2,3,4,5,6,7], "תאריים": [1,2,...,17], ...}
+    """
+    logger.info("Querying wiki for all player-achievement categories...")
+    raw_cats = [
+        cat.title(with_ns=False)
+        for cat in site.allcategories(prefix=CATEGORY_PREFIX)
+    ]
+    logger.info(f"Found {len(raw_cats)} matching categories")
+
+    # Pattern: "שחקני כדורגל שזכו ב-{N} {TYPE}"
+    pattern = re.compile(r"^שחקני כדורגל שזכו ב-(\d+) (.+)$")
+    grouped: dict[str, list[int]] = defaultdict(list)
+    for cat in raw_cats:
+        m = pattern.match(cat)
+        if m:
+            n, type_name = int(m.group(1)), m.group(2)
+            grouped[type_name].append(n)
+        else:
+            logger.warning(f"Unexpected category name, skipping: {cat!r}")
+
+    return {t: sorted(ns) for t, ns in grouped.items()}
+
+
+def build_template_wikitext(type_name: str, label: str, numbers: list[int]) -> str:
+    """
+    Build the full wikitext for a pill-navigation template.
+    The template takes one positional parameter {{{1}}}: the current number.
+    """
+    pills = []
+    for n in numbers:
+        cat_full = f"קטגוריה:שחקני כדורגל שזכו ב-{n} {type_name}"
+        current_html = f'<span class="{_PILL_ACTIVE_CLASS}">{n}</span>'
+        linked_html = f'[[:{ cat_full }|<span class="{_PILL_CLASS}">{n}</span>]]'
+        # Use string concatenation to avoid f-string brace-escaping issues with
+        # MediaWiki's {{{1}}} parameter syntax and {{#ifeq:...}} parser function.
+        pill = "{{#ifeq:{{{1}}}|" + str(n) + "|" + current_html + "|" + linked_html + "}}"
+        pills.append(pill)
+
+    pills_wikitext = "\n".join(pills)
+
+    return (
+        "<includeonly>\n"
+        '<div style="text-align:center;padding:8px 12px;background:#f8f9fa;'
+        'border:1px solid #a2a9b1;border-radius:4px;margin:4px 0 10px 0;">\n'
+        f'<div style="font-size:12px;color:#72777d;margin-bottom:6px;">{label}</div>\n'
+        "<div>\n"
+        f"{pills_wikitext}\n"
+        "</div>\n"
+        "</div>\n"
+        "</includeonly>\n"
+        "<noinclude>[[קטגוריה:תבניות ניווט]]</noinclude>"
+    )
+
+
+def create_or_update_template(
+    site: pywikibot.Site,
+    type_name: str,
+    label: str,
+    numbers: list[int],
+    dry_run: bool,
+) -> None:
+    template_title = f"תבנית:{TEMPLATE_PREFIX}{type_name}"
+    page = pywikibot.Page(site, template_title)
+    new_content = build_template_wikitext(type_name, label, numbers)
+
+    if page.exists() and page.text == new_content:
+        logger.info(f"Template already up-to-date: {template_title}")
+        return
+
+    action = "CREATE" if not page.exists() else "UPDATE"
+    logger.info(f"[{action}] Template: {template_title}")
+    if dry_run:
+        logger.info(f"  [DRY-RUN] Would set content:\n{new_content}\n")
+        return
+
+    page.text = new_content
+    page.save(summary="בוט: הוספת תבנית ניווט לקטגוריות שחקני כדורגל לפי הישגים", minor=False)
+
+
+def add_navbar_to_category_page(
+    site: pywikibot.Site,
+    type_name: str,
+    n: int,
+    dry_run: bool,
+) -> None:
+    template_call = f"{{{{{TEMPLATE_PREFIX}{type_name}|{n}}}}}"
+    cat_title = f"קטגוריה:שחקני כדורגל שזכו ב-{n} {type_name}"
+    page = pywikibot.Page(site, cat_title)
+
+    existing = page.text  # '' for category pages with no explicit wikitext
+
+    if template_call in existing:
+        logger.info(f"Nav already present: {cat_title}")
+        return
+
+    new_content = template_call + ("\n" + existing if existing.strip() else "")
+
+    logger.info(f"[EDIT] Category page: {cat_title}")
+    if dry_run:
+        logger.info(f"  [DRY-RUN] Would set content:\n{new_content}\n")
+        return
+
+    page.text = new_content
+    page.save(summary="בוט: הוספת ניווט לקטגוריה", minor=True)
+
+
+def main(dry_run: bool = True, test: bool = False) -> None:
+    site = get_site()
+
+    type_map = discover_categories(site)
+    logger.info(f"Competition types found: {list(type_map.keys())}")
+
+    for type_name, numbers in sorted(type_map.items()):
+        label = TYPE_LABELS.get(type_name, f"שחקני כדורגל לפי מספר {type_name}")
+        logger.info(f"\n--- {type_name} ({numbers}) ---")
+
+        create_or_update_template(site, type_name, label, numbers, dry_run)
+
+        for n in numbers:
+            add_navbar_to_category_page(site, type_name, n, dry_run)
+            if test:
+                logger.info("Test mode: stopping after first page.")
+                return
+
+    logger.info("\nDone.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--live", action="store_true", help="Actually edit the wiki (default: dry-run)")
+    parser.add_argument("--test", action="store_true", help="Only process one template and one category page")
+    args = parser.parse_args()
+    main(dry_run=not args.live, test=args.test)

--- a/src/maccabipediabot/maintenance/football/add_player_category_navbars.py
+++ b/src/maccabipediabot/maintenance/football/add_player_category_navbars.py
@@ -1,12 +1,14 @@
 """
 Add pill-style navigation bars to player achievement category pages.
 
-For each sport and competition-type series (e.g. "שחקני כדורגל שזכו ב-N אליפויות"),
-this script:
-  1. Discovers all existing numbered categories via the MediaWiki API.
-  2. Creates (or updates) one navigation template per competition type,
+Auto-discovers all category series matching the pattern:
+  "שחקני {sport} שזכו ב-{N} {type}"  (e.g. שחקני כדורגל שזכו ב-3 אליפויות)
+  "שחקני {sport} שזכו {N} {type}"    (e.g. שחקני כדורגל שזכו 5 עונות במכבי)
+
+For each discovered series this script:
+  1. Creates (or updates) one navigation template per competition type,
      e.g. "תבנית:ניווט שחקני כדורגל - אליפויות".
-  3. Edits each category page to prepend the template call so the nav bar
+  2. Edits each category page to prepend the template call so the nav bar
      appears above the member list.
 
 Usage:
@@ -39,84 +41,117 @@ logger = logging.getLogger(__name__)
 _PILL_CLASS = "nmpAchievementsNavPill"
 _PILL_ACTIVE_CLASS = "nmpAchievementsNavPillActive"
 
+# Human-readable labels for known competition types.
+# Fallback: "{type_name}:"
+TYPE_LABELS = {
+    "אליפויות":             "זכיות באליפות:",
+    "אלוף האלופים":         "זכיות באלוף האלופים:",
+    "אלוף האליפיים":        "זכיות באלוף האלופים:",
+    "גביעי מדינה":          "זכיות בגביע המדינה:",
+    "גביעי טוטו":           "זכיות בגביע הטוטו:",
+    "גביעי ליליאן":         "זכיות בגביע ליליאן:",
+    "גביעי אסיה לאלופות":   "זכיות בגביע אסיה לאלופות:",
+    "גביעי אטקין":          "זכיות בגביע אטקין:",
+    "תארים":                "סך כל התארים:",
+    "תאריים":               "סך כל התארים:",
+    "עונות במכבי":          "עונות במכבי:",
+    "עונות":                "עונות במכבי:",
+}
+
+# Patterns to match category names (order matters — most specific first):
+#   Pattern A:  "שחקני {sport} שזכו ב-{N} {type}"  e.g. שחקני כדורגל שזכו ב-3 אליפויות
+#   Pattern B:  "שחקני {sport} שזכו {N} {type}"    e.g. שחקני כדורגל שזכו 5 תארים
+#   Pattern C:  "שחקני {sport} ששיחקו {N} {type}"  e.g. שחקני כדורגל ששיחקו 7 עונות במכבי
+#   Pattern D:  "שחקנים ששיחקו {N} {type}"          e.g. שחקנים ששיחקו 10 עונות
+_PATTERN_A = re.compile(r"^שחקני (.+?) שזכו ב-(\d+) (.+)$")
+_PATTERN_B = re.compile(r"^שחקני (.+?) שזכו (\d+) (.+)$")
+_PATTERN_C = re.compile(r"^שחקני (.+?) ששיחקו (\d+) (.+)$")
+_PATTERN_D = re.compile(r"^שחקנים ששיחקו (\d+) (.+)$")
+
 
 @dataclass
-class SportConfig:
-    name: str           # e.g. "כדורגל"
-    category_prefix: str  # prefix for allcategories query
-    template_prefix: str  # prefix for template titles
-    type_labels: dict[str, str]  # type_name -> label shown above pills
+class CategorySeries:
+    sport: str        # e.g. "כדורגל"
+    type_name: str    # e.g. "אליפויות"
+    cat_prefix: str   # e.g. "שחקני כדורגל שזכו ב-" or "שחקני כדורגל שזכו "
+    numbers: list[int]
+
+    @property
+    def template_name(self) -> str:
+        return f"ניווט שחקני {self.sport} - {self.type_name}"
+
+    def cat_title(self, n: int) -> str:
+        # cat_prefix already ends with the right separator (e.g. "ב-" or " ")
+        return f"קטגוריה:{self.cat_prefix}{n} {self.type_name}"
+
+    def template_call(self, n: int) -> str:
+        return f"{{{{{self.template_name}|{n}}}}}"
 
 
-SPORTS = [
-    SportConfig(
-        name="כדורגל",
-        category_prefix="שחקני כדורגל שזכו ב-",
-        template_prefix="ניווט שחקני כדורגל - ",
-        type_labels={
-            "אליפויות":             "זכיות באליפות:",
-            "אלוף האלופים":         "זכיות באלוף האלופים:",
-            "אלוף האליפיים":        "זכיות באלוף האלופים:",
-            "גביעי מדינה":          "זכיות בגביע המדינה:",
-            "גביעי טוטו":           "זכיות בגביע הטוטו:",
-            "גביעי ליליאן":         "זכיות בגביע ליליאן:",
-            "גביעי אסיה לאלופות":   "זכיות בגביע אסיה לאלופות:",
-            "תאריים":               "סך כל התארים:",
-        },
-    ),
-    SportConfig(
-        name="כדורעף",
-        category_prefix="שחקני כדורעף שזכו ב-",
-        template_prefix="ניווט שחקני כדורעף - ",
-        type_labels={
-            "אליפויות":     "זכיות באליפות:",
-            "גביעי אטקין":  "זכיות בגביע אטקין:",
-            "גביעי מדינה":  "זכיות בגביע המדינה:",
-            "תאריים":       "סך כל התארים:",
-            "תארים":        "סך כל התארים:",
-        },
-    ),
-]
-
-
-def discover_categories(site: pywikibot.Site, sport: SportConfig) -> dict[str, list[int]]:
+def discover_all_series(
+    site: pywikibot.Site, sport_filter: str | None = None
+) -> list[CategorySeries]:
     """
-    Query the wiki for all categories matching this sport's prefix.
-    Returns a dict mapping type_name -> sorted list of numbers.
+    Query all categories starting with 'שחקני' and parse them into series.
+    Handles both 'שזכו ב-N' and 'שזכו N' patterns automatically.
     """
-    logger.info(f"[{sport.name}] Querying categories with prefix: {sport.category_prefix!r}")
-    raw_cats = [
-        cat.title(with_ns=False)
-        for cat in site.allcategories(prefix=sport.category_prefix)
+    logger.info("Querying all 'שחקני' categories from wiki...")
+    grouped: dict[tuple, dict] = defaultdict(lambda: {"cat_prefix": None, "numbers": []})
+
+    # "שחקני" covers both "שחקני {sport}" and "שחקנים" (since שחקנים starts with שחקני)
+    for cat in site.allcategories(prefix="שחקני"):
+            title = cat.title(with_ns=False)
+
+            ma = _PATTERN_A.match(title)
+            mb = _PATTERN_B.match(title)
+            mc = _PATTERN_C.match(title)
+            md = _PATTERN_D.match(title)
+
+            if ma:
+                sport, n, type_name = ma.group(1), int(ma.group(2)), ma.group(3)
+                cat_prefix = f"שחקני {sport} שזכו ב-"
+            elif mb:
+                sport, n, type_name = mb.group(1), int(mb.group(2)), mb.group(3)
+                cat_prefix = f"שחקני {sport} שזכו "
+            elif mc:
+                sport, n, type_name = mc.group(1), int(mc.group(2)), mc.group(3)
+                cat_prefix = f"שחקני {sport} ששיחקו "
+            elif md:
+                sport, n, type_name = "כללי", int(md.group(1)), md.group(2)
+                cat_prefix = "שחקנים ששיחקו "
+            else:
+                continue
+
+            if sport_filter and sport != sport_filter:
+                continue
+
+            key = (sport, type_name)
+            grouped[key]["cat_prefix"] = cat_prefix
+            grouped[key]["numbers"].append(n)
+
+    series = [
+        CategorySeries(
+            sport=key[0],
+            type_name=key[1],
+            cat_prefix=data["cat_prefix"],
+            numbers=sorted(data["numbers"]),
+        )
+        for key, data in grouped.items()
     ]
-    logger.info(f"[{sport.name}] Found {len(raw_cats)} matching categories")
 
-    pattern = re.compile(r"^.+שזכו ב-(\d+) (.+)$")
-    grouped: dict[str, list[int]] = defaultdict(list)
-    for cat in raw_cats:
-        m = pattern.match(cat)
-        if m:
-            n, type_name = int(m.group(1)), m.group(2)
-            grouped[type_name].append(n)
-        else:
-            logger.warning(f"Unexpected category name, skipping: {cat!r}")
-
-    return {t: sorted(ns) for t, ns in grouped.items()}
+    logger.info(f"Discovered {len(series)} category series")
+    return series
 
 
-def build_template_wikitext(
-    sport: SportConfig, type_name: str, label: str, numbers: list[int]
-) -> str:
+def build_template_wikitext(series: CategorySeries, label: str) -> str:
     """Build the full wikitext for a pill-navigation template."""
     pills = []
-    for n in numbers:
-        cat_full = f"קטגוריה:{sport.category_prefix}{n} {type_name}"
+    for n in series.numbers:
+        cat_full = series.cat_title(n)
         current_html = f'<span class="{_PILL_ACTIVE_CLASS}">{n}</span>'
-        linked_html = f'[[:{ cat_full }|<span class="{_PILL_CLASS}">{n}</span>]]'
+        linked_html = f'[[:{cat_full}|<span class="{_PILL_CLASS}">{n}</span>]]'
         pill = "{{#ifeq:{{{1}}}|" + str(n) + "|" + current_html + "|" + linked_html + "}}"
         pills.append(pill)
-
-    pills_wikitext = "\n".join(pills)
 
     return (
         "<includeonly>\n"
@@ -124,7 +159,7 @@ def build_template_wikitext(
         'border:1px solid #a2a9b1;border-radius:4px;margin:4px 0 10px 0;">\n'
         f'<div style="font-size:12px;color:#72777d;margin-bottom:6px;">{label}</div>\n'
         "<div>\n"
-        f"{pills_wikitext}\n"
+        + "\n".join(pills) + "\n"
         "</div>\n"
         "</div>\n"
         "</includeonly>\n"
@@ -133,16 +168,11 @@ def build_template_wikitext(
 
 
 def create_or_update_template(
-    site: pywikibot.Site,
-    sport: SportConfig,
-    type_name: str,
-    label: str,
-    numbers: list[int],
-    dry_run: bool,
+    site: pywikibot.Site, series: CategorySeries, label: str, dry_run: bool
 ) -> None:
-    template_title = f"תבנית:{sport.template_prefix}{type_name}"
+    template_title = f"תבנית:{series.template_name}"
     page = pywikibot.Page(site, template_title)
-    new_content = build_template_wikitext(sport, type_name, label, numbers)
+    new_content = build_template_wikitext(series, label)
 
     if page.exists() and page.text == new_content:
         logger.info(f"Template already up-to-date: {template_title}")
@@ -159,17 +189,12 @@ def create_or_update_template(
 
 
 def add_navbar_to_category_page(
-    site: pywikibot.Site,
-    sport: SportConfig,
-    type_name: str,
-    n: int,
-    dry_run: bool,
+    site: pywikibot.Site, series: CategorySeries, n: int, dry_run: bool
 ) -> None:
-    template_call = f"{{{{{sport.template_prefix}{type_name}|{n}}}}}"
-    cat_title = f"קטגוריה:{sport.category_prefix}{n} {type_name}"
+    template_call = series.template_call(n)
+    cat_title = series.cat_title(n)
     page = pywikibot.Page(site, cat_title)
-
-    existing = page.text  # '' for category pages with no explicit wikitext
+    existing = page.text
 
     if template_call in existing:
         logger.info(f"Nav already present: {cat_title}")
@@ -186,35 +211,21 @@ def add_navbar_to_category_page(
     page.save(summary="בוט: הוספת ניווט לקטגוריה", minor=True)
 
 
-def process_sport(
-    site: pywikibot.Site, sport: SportConfig, dry_run: bool, test: bool
-) -> None:
-    type_map = discover_categories(site, sport)
-    logger.info(f"[{sport.name}] Types found: {list(type_map.keys())}")
+def main(dry_run: bool = True, test: bool = False, sport_filter: str | None = None) -> None:
+    site = get_site()
+    all_series = discover_all_series(site, sport_filter=sport_filter)
 
-    for type_name, numbers in sorted(type_map.items()):
-        label = sport.type_labels.get(type_name, f"זכיות ב{type_name}:")
-        logger.info(f"\n--- [{sport.name}] {type_name} ({numbers}) ---")
+    for series in sorted(all_series, key=lambda s: (s.sport, s.type_name)):
+        label = TYPE_LABELS.get(series.type_name, f"{series.type_name}:")
+        logger.info(f"\n--- [{series.sport}] {series.type_name} ({series.numbers}) ---")
 
-        create_or_update_template(site, sport, type_name, label, numbers, dry_run)
+        create_or_update_template(site, series, label, dry_run)
 
-        for n in numbers:
-            add_navbar_to_category_page(site, sport, type_name, n, dry_run)
+        for n in series.numbers:
+            add_navbar_to_category_page(site, series, n, dry_run)
             if test:
                 logger.info("Test mode: stopping after first page.")
                 return
-
-
-def main(dry_run: bool = True, test: bool = False, sport_filter: str | None = None) -> None:
-    site = get_site()
-
-    sports = [s for s in SPORTS if sport_filter is None or s.name == sport_filter]
-    if not sports:
-        logger.error(f"Unknown sport: {sport_filter!r}. Available: {[s.name for s in SPORTS]}")
-        return
-
-    for sport in sports:
-        process_sport(site, sport, dry_run, test)
 
     logger.info("\nDone.")
 


### PR DESCRIPTION
## Summary

- Adds pill-style navigation bars to all player achievement category pages (e.g. \"שחקני כדורגל שזכו ב-3 אליפויות\" shows a nav bar linking to 1 | 2 | **3** | 4 | 5 | 6 | 7)
- Implemented via MediaWiki templates + bot script; CSS classes added to `MediaWiki:Common.css`
- Auto-discovers all sports and category series from the wiki — no hardcoded sport lists, handles football, volleyball, and any future sport automatically
- Supports four Hebrew category naming patterns: `שזכו ב-N`, `שזכו N`, `ששיחקו N` (per-sport), and `שחקנים ששיחקו N` (cross-sport)

## Test plan
- [ ] Dry-run: `python -m maccabipediabot.maintenance.football.add_player_category_navbars` — verify all 14 series discovered with correct numbers, no duplicates
- [ ] Spot-check single page: `--live --test --sport כדורגל`
- [ ] Full live run: `--live`

🤖 Generated with [Claude Code](https://claude.com/claude-code)