### PR TITLE
chore: gitignore Claude Code scratch directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,8 @@ pywikibot.lwp
 # AI Agents
 .agents-temp/*
 !.agents-temp/.gitkeep
+
+# Claude Code
+.claude/worktrees/
+.claude/scratch/
+.claude/research/


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/`, `.claude/scratch/`, `.claude/research/` to `.gitignore`
- Establishes convention: Claude-generated temp files go under `.claude/` subdirectories, never at the repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)