### PR TITLE
chore: improve dev tooling — wslview, uv sync, cleanup

### DIFF
--- a/.claude/hooks/create-worktree.sh
+++ b/.claude/hooks/create-worktree.sh
@@ -29,13 +29,11 @@ SRC="${REPO_ROOT}/.claude/settings.local.json"
 if [ -f "$SRC" ]; then
     mkdir -p "${WT_DIR}/.claude"
     cp "$SRC" "${WT_DIR}/.claude/settings.local.json"
-    echo "  copied settings.local.json" >&2
 fi
 
-# Symlink .venv
-if [ -d "${REPO_ROOT}/.venv" ] && [ ! -e "${WT_DIR}/.venv" ]; then
-    ln -s "${REPO_ROOT}/.venv" "${WT_DIR}/.venv"
-    echo "  linked .venv" >&2
+# Create independent venv with packages (uv is ~10x faster than pip)
+if [ ! -e "${WT_DIR}/.venv" ]; then
+    uv sync --directory "${WT_DIR}" >&2
 fi
 
 # Output the worktree path (required by Claude Code)

--- a/.claude/scripts/open-in-browser.sh
+++ b/.claude/scripts/open-in-browser.sh
@@ -8,5 +8,4 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 
-# explorer.exe returns exit code 1 even on success in WSL
-explorer.exe "$1" || true
+wslview "$1"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,6 +57,7 @@
       "Bash(sed:*)",
       "Bash(host:*)",
       "Bash(curl:*)",
+      "Bash(uv run:*)",
       "mcp__trello__*",
       "mcp__youtube__*"
     ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 
 ## 2. Environment
 - Running scripts requires `MACCABIPEDIA_UA_SCRIPT` env var — set in `settings.json` env. Pywikibot reads credentials from `user-password.py` directly; never use `source ~/.secrets`.
+- **Always use `uv run python` instead of `python`** — this auto-detects the local `.venv` without activation. Works in both the main repo and worktrees.
 
 ## 3. Git Workflow
 - **Always work on a feature branch.** Nothing is committed directly to `master`; everything goes through a PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 ## 2. Environment
 - Running scripts requires `MACCABIPEDIA_UA_SCRIPT` env var — set in `settings.json` env. Pywikibot reads credentials from `user-password.py` directly; never use `source ~/.secrets`.
-- **Always use `uv run python` instead of `python`** — this auto-detects the local `.venv` without activation. Works in both the main repo and worktrees.
+- **Always use `uv run` instead of running commands directly** — e.g. `uv run python`, `uv run pytest`, `uv run mypy`. This auto-detects the local `.venv` without activation. Works in both the main repo and worktrees.
 
 ## 3. Git Workflow
 - **Always work on a feature branch.** Nothing is committed directly to `master`; everything goes through a PR.


### PR DESCRIPTION
## Summary
- Switch `open-in-browser.sh` to `wslview` (proper WSL2 tool, replaces `explorer.exe`/`rundll32.exe` hacks)
- Worktree hook: use `uv sync` for independent venv instead of symlinking `.venv`, remove debug logging
- Add `Bash(uv run:*)` permission to settings.json
- Document `uv run python` usage in CLAUDE.md

## Test plan
- [x] Tested `wslview` opens URLs in Chrome correctly
- [ ] Verify worktree creation still works with `uv sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)