### PR TITLE
ci: add test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@v6
+      - name: Install dependencies
+        run: uv sync
+      - name: Run tests
+        run: uv run pytest packages/maccabipediabot/tests packages/maccabipedia-mcp/tests -v


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs pytest on push/PR to `master`
- Runs tests for `maccabipediabot` and `maccabipedia-mcp` packages (52 tests)
- Excludes `maccabistats` tests since they require network access to the live wiki

## Test plan
- [x] All 52 tests pass locally
- [ ] Verify the workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)