### PR TITLE
fix: include players data in pickle for offline loading

### DIFF
--- a/packages/maccabistats/src/maccabistats/error_finder/error_finder.py
+++ b/packages/maccabistats/src/maccabistats/error_finder/error_finder.py
@@ -31,7 +31,8 @@ class ErrorsFinder:
                                 if not game.technical_result
                                 if 11 != len(game.maccabi_team.lineup_players)]
 
-        return MaccabiGamesStats(missing_lineup_games)
+        return self.maccabi_games_stats._create_filtered(missing_lineup_games,
+                                                                'Games without 11 lineup players')
 
     def get_dates_with_more_than_one_game(self):
         """
@@ -62,7 +63,7 @@ class ErrorsFinder:
                  if (game.maccabi_team.score + game.not_maccabi_team.score != len(
                 game.goals())) and not game.technical_result]
 
-        return MaccabiGamesStats(games)
+        return self.maccabi_games_stats._create_filtered(games, 'Games with missing goals events')
 
     def get_games_with_wrong_goals_team_belonging(self):
         """ Maccabi score in the game should be equal to the maccabi score that written in the last goal event
@@ -87,7 +88,7 @@ class ErrorsFinder:
 
         games = list(filter(game_has_wrong_goals_belonging, self.maccabi_games_stats))
 
-        return MaccabiGamesStats(games)
+        return self.maccabi_games_stats._create_filtered(games, 'Games with wrong goals belonging')
 
     def get_players_with_event_but_without_lineup_or_substitution(self):
         """ Every player that has any event should has atleast lineup or substitution or bench in event """
@@ -164,7 +165,7 @@ class ErrorsFinder:
             for game in season:
                 fixtures_from_all_seasons[f"Season {season[0].season} Fixture {game.league_fixture}"].append(game)
 
-        double_fixtures = [(season_and_fixture, MaccabiGamesStats(games)) for season_and_fixture, games in
+        double_fixtures = [(season_and_fixture, self.maccabi_games_stats._create_filtered(games, f'Double fixture: {season_and_fixture}')) for season_and_fixture, games in
                            fixtures_from_all_seasons.items() if
                            len(games) > 1]
 

--- a/packages/maccabistats/src/maccabistats/error_finder/error_finder.py
+++ b/packages/maccabistats/src/maccabistats/error_finder/error_finder.py
@@ -31,7 +31,7 @@ class ErrorsFinder:
                                 if not game.technical_result
                                 if 11 != len(game.maccabi_team.lineup_players)]
 
-        return self.maccabi_games_stats._create_filtered(missing_lineup_games,
+        return self.maccabi_games_stats.create_maccabi_games_stats_with_filtered_games(missing_lineup_games,
                                                                 'Games without 11 lineup players')
 
     def get_dates_with_more_than_one_game(self):
@@ -63,7 +63,7 @@ class ErrorsFinder:
                  if (game.maccabi_team.score + game.not_maccabi_team.score != len(
                 game.goals())) and not game.technical_result]
 
-        return self.maccabi_games_stats._create_filtered(games, 'Games with missing goals events')
+        return self.maccabi_games_stats.create_maccabi_games_stats_with_filtered_games(games, 'Games with missing goals events')
 
     def get_games_with_wrong_goals_team_belonging(self):
         """ Maccabi score in the game should be equal to the maccabi score that written in the last goal event
@@ -88,7 +88,7 @@ class ErrorsFinder:
 
         games = list(filter(game_has_wrong_goals_belonging, self.maccabi_games_stats))
 
-        return self.maccabi_games_stats._create_filtered(games, 'Games with wrong goals belonging')
+        return self.maccabi_games_stats.create_maccabi_games_stats_with_filtered_games(games, 'Games with wrong goals belonging')
 
     def get_players_with_event_but_without_lineup_or_substitution(self):
         """ Every player that has any event should has atleast lineup or substitution or bench in event """
@@ -165,7 +165,7 @@ class ErrorsFinder:
             for game in season:
                 fixtures_from_all_seasons[f"Season {season[0].season} Fixture {game.league_fixture}"].append(game)
 
-        double_fixtures = [(season_and_fixture, self.maccabi_games_stats._create_filtered(games, f'Double fixture: {season_and_fixture}')) for season_and_fixture, games in
+        double_fixtures = [(season_and_fixture, self.maccabi_games_stats.create_maccabi_games_stats_with_filtered_games(games, f'Double fixture: {season_and_fixture}')) for season_and_fixture, games in
                            fixtures_from_all_seasons.items() if
                            len(games) > 1]
 

--- a/packages/maccabistats/src/maccabistats/maccabipedia/players.py
+++ b/packages/maccabistats/src/maccabistats/maccabipedia/players.py
@@ -72,6 +72,7 @@ class MaccabiPediaPlayers(object):
         instance.home_players = {player_data.name for player_data in players_data.values() if
                                  player_data.is_home_player}
         cls._instance = instance
+        return instance
 
     @property
     def raw_players_data(self) -> Dict[str, MaccabiPediaPlayerData]:

--- a/packages/maccabistats/src/maccabistats/maccabipedia/players.py
+++ b/packages/maccabistats/src/maccabistats/maccabipedia/players.py
@@ -60,3 +60,19 @@ class MaccabiPediaPlayers(object):
             cls._instance = cls()
 
         return cls._instance
+
+    @classmethod
+    def load_from_cache(cls, players_data: Dict[str, MaccabiPediaPlayerData]):
+        """Initialize the singleton from cached data without crawling from the internet."""
+        instance = object.__new__(cls)
+        instance._players_data = players_data
+        instance.players_dates = defaultdict(MaccabiPediaPlayers.default_birth_day_value,
+                                             {player_name: player_data.birth_date for player_name, player_data in
+                                              players_data.items()})
+        instance.home_players = {player_data.name for player_data in players_data.values() if
+                                 player_data.is_home_player}
+        cls._instance = instance
+
+    @property
+    def raw_players_data(self) -> Dict[str, MaccabiPediaPlayerData]:
+        return self._players_data

--- a/packages/maccabistats/src/maccabistats/maccabipedia/players.py
+++ b/packages/maccabistats/src/maccabistats/maccabipedia/players.py
@@ -61,19 +61,3 @@ class MaccabiPediaPlayers(object):
 
         return cls._instance
 
-    @classmethod
-    def load_from_cache(cls, players_data: Dict[str, MaccabiPediaPlayerData]):
-        """Initialize the singleton from cached data without crawling from the internet."""
-        instance = object.__new__(cls)
-        instance._players_data = players_data
-        instance.players_dates = defaultdict(MaccabiPediaPlayers.default_birth_day_value,
-                                             {player_name: player_data.birth_date for player_name, player_data in
-                                              players_data.items()})
-        instance.home_players = {player_data.name for player_data in players_data.values() if
-                                 player_data.is_home_player}
-        cls._instance = instance
-        return instance
-
-    @property
-    def raw_players_data(self) -> Dict[str, MaccabiPediaPlayerData]:
-        return self._players_data

--- a/packages/maccabistats/src/maccabistats/parse/maccabistats_source.py
+++ b/packages/maccabistats/src/maccabistats/parse/maccabistats_source.py
@@ -5,6 +5,7 @@ import pickle
 from datetime import datetime
 from pathlib import Path
 
+from maccabistats.maccabipedia.players import MaccabiPediaPlayers
 from maccabistats.parse.general_fixes import run_general_fixes
 from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
 
@@ -47,9 +48,8 @@ class MaccabiStatsSource(object):
 
         logger.info(f"Starting to parse maccabi games from: {self.name}")
         parsed_games = self._rerun_source()
-        from maccabistats.maccabipedia.players import MaccabiPediaPlayers
         self.maccabi_games_stats = MaccabiGamesStats(parsed_games, f'Source: {self.name}',
-                                                      maccabipedia_players=MaccabiPediaPlayers.get_players_data())
+                                                      players_data=MaccabiPediaPlayers.get_players_data())
 
     def _rerun_source(self):
         """

--- a/packages/maccabistats/src/maccabistats/parse/maccabistats_source.py
+++ b/packages/maccabistats/src/maccabistats/parse/maccabistats_source.py
@@ -47,7 +47,9 @@ class MaccabiStatsSource(object):
 
         logger.info(f"Starting to parse maccabi games from: {self.name}")
         parsed_games = self._rerun_source()
-        self.maccabi_games_stats = MaccabiGamesStats(parsed_games, f'Source: {self.name}')
+        from maccabistats.maccabipedia.players import MaccabiPediaPlayers
+        self.maccabi_games_stats = MaccabiGamesStats(parsed_games, f'Source: {self.name}',
+                                                      maccabipedia_players=MaccabiPediaPlayers.get_players_data())
 
     def _rerun_source(self):
         """

--- a/packages/maccabistats/src/maccabistats/parse/parse_from_all_sites.py
+++ b/packages/maccabistats/src/maccabistats/parse/parse_from_all_sites.py
@@ -125,7 +125,9 @@ def _load_from_source(source):
     source.run_general_fixes()
     source.run_specific_fixes()
 
-    return MaccabiGamesStats(source.maccabi_games_stats, description=f'Source: {source.name}')
+    loaded = source.maccabi_games_stats
+    return MaccabiGamesStats(loaded, description=f'Source: {source.name}',
+                             _maccabipedia_players=getattr(loaded, '_maccabipedia_players', None))
 
 
 def load_from_maccabipedia_source():

--- a/packages/maccabistats/src/maccabistats/parse/parse_from_all_sites.py
+++ b/packages/maccabistats/src/maccabistats/parse/parse_from_all_sites.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from maccabistats.config import MaccabiStatsConfigSingleton
+from maccabistats.maccabipedia.players import MaccabiPediaPlayers
 from maccabistats.parse.general_fixes import run_general_fixes
 from maccabistats.parse.maccabi_tlv_site.maccabi_tlv_site_source import MaccabiTlvSiteSource
 from maccabistats.parse.maccabipedia.maccabipedia_source import MaccabiPediaSource
@@ -115,9 +116,8 @@ def merge_maccabi_games_from_all_input_serialized_sources():
                                                            maccabi_games_stats_from_all_sources[1])
     logger.info("Running general fixes on merged maccabi games stats object")
 
-    from maccabistats.maccabipedia.players import MaccabiPediaPlayers
     maccabistats_games = run_general_fixes(MaccabiGamesStats(merged_maccabistats_games,
-                                                              maccabipedia_players=MaccabiPediaPlayers.get_players_data()))
+                                                              players_data=MaccabiPediaPlayers.get_players_data()))
     return maccabistats_games
 
 
@@ -129,7 +129,7 @@ def _load_from_source(source):
 
     loaded = source.maccabi_games_stats
     return MaccabiGamesStats(loaded.games, description=f'Source: {source.name}',
-                             maccabipedia_players=getattr(loaded, 'maccabipedia_players', None))
+                             players_data=loaded.players_data)
 
 
 def load_from_maccabipedia_source():

--- a/packages/maccabistats/src/maccabistats/parse/parse_from_all_sites.py
+++ b/packages/maccabistats/src/maccabistats/parse/parse_from_all_sites.py
@@ -115,7 +115,9 @@ def merge_maccabi_games_from_all_input_serialized_sources():
                                                            maccabi_games_stats_from_all_sources[1])
     logger.info("Running general fixes on merged maccabi games stats object")
 
-    maccabistats_games = run_general_fixes(MaccabiGamesStats(merged_maccabistats_games))
+    from maccabistats.maccabipedia.players import MaccabiPediaPlayers
+    maccabistats_games = run_general_fixes(MaccabiGamesStats(merged_maccabistats_games,
+                                                              maccabipedia_players=MaccabiPediaPlayers.get_players_data()))
     return maccabistats_games
 
 

--- a/packages/maccabistats/src/maccabistats/parse/parse_from_all_sites.py
+++ b/packages/maccabistats/src/maccabistats/parse/parse_from_all_sites.py
@@ -126,8 +126,8 @@ def _load_from_source(source):
     source.run_specific_fixes()
 
     loaded = source.maccabi_games_stats
-    return MaccabiGamesStats(loaded, description=f'Source: {source.name}',
-                             _maccabipedia_players=getattr(loaded, '_maccabipedia_players', None))
+    return MaccabiGamesStats(loaded.games, description=f'Source: {source.name}',
+                             maccabipedia_players=getattr(loaded, 'maccabipedia_players', None))
 
 
 def load_from_maccabipedia_source():

--- a/packages/maccabistats/src/maccabistats/scripts/players_goals_at_first_games.py
+++ b/packages/maccabistats/src/maccabistats/scripts/players_goals_at_first_games.py
@@ -17,7 +17,8 @@ if __name__ == '__main__':
     players_to_show = []
 
     for player, games in players_games.items():
-        first_games = MaccabiGamesStats(games[:FIRST_GAMES_COUNT])
+        first_games = maccabi_games.create_maccabi_games_stats_with_filtered_games(
+            games[:FIRST_GAMES_COUNT], f'First {FIRST_GAMES_COUNT} games: {player}')
         player_goals = [goals for name, goals in first_games.players.best_scorers if name == player] or [0]
         player_goals = player_goals[0]
         if player_goals >= GOALS_TO_SHOW_FROM:

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -46,9 +46,19 @@ logger = logging.getLogger(__name__)
 class MaccabiGamesStats:
     _DEFAULT_DESCRIPTION = 'All games'
 
-    def __init__(self, games: List[GameData], description: str = None) -> None:
+    def __init__(self, games: List[GameData], description: str = None,
+                 _maccabipedia_players: MaccabiPediaPlayers = None) -> None:
         self.games: List[GameData] = sorted(games, key=lambda g: g.date)  # Sort the games by date
         self.description = description or self._DEFAULT_DESCRIPTION
+
+        # Store players data so it's pickled with the games (no internet needed on load).
+        # Only crawl when not provided and there are games to process.
+        if _maccabipedia_players is not None:
+            self._maccabipedia_players = _maccabipedia_players
+        elif self.games:
+            self._maccabipedia_players = MaccabiPediaPlayers.get_players_data()
+        else:
+            self._maccabipedia_players = None
 
         self.coaches = MaccabiGamesCoachesStats(self)
         self.players = MaccabiGamesPlayersStats(self)
@@ -76,33 +86,21 @@ class MaccabiGamesStats:
 
         self.version = maccabistats_version
 
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        # Include players data in the pickle so loading doesn't require internet
-        players_instance = MaccabiPediaPlayers._instance
-        if players_instance is not None:
-            state['_players_data_cache'] = players_instance.raw_players_data
-        return state
-
-    def __setstate__(self, state):
-        # Restore players data singleton before reconstructing stats objects
-        players_data_cache = state.pop('_players_data_cache', None)
-        if players_data_cache is not None and MaccabiPediaPlayers._instance is None:
-            MaccabiPediaPlayers.load_from_cache(players_data_cache)
-
-        self.__dict__.update(state)
+    def _create_filtered(self, games: List[GameData], description: str) -> MaccabiGamesStats:
+        """Create a filtered MaccabiGamesStats that inherits the players data."""
+        return MaccabiGamesStats(games, description, _maccabipedia_players=self._maccabipedia_players)
 
     # region home_away
 
     @property
     def home_games(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.is_maccabi_home_team],
-                                 self._new_description('Home games'))
+        return self._create_filtered([game for game in self.games if game.is_maccabi_home_team],
+                                     self._new_description('Home games'))
 
     @property
     def away_games(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if not game.is_maccabi_home_team],
-                                 self._new_description('Away games'))
+        return self._create_filtered([game for game in self.games if not game.is_maccabi_home_team],
+                                     self._new_description('Away games'))
 
     # endregion
 
@@ -110,28 +108,28 @@ class MaccabiGamesStats:
 
     @property
     def trophy_games(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.competition in TROPHY_COMPETITIONS],
-                                 self._new_description('Trophy games'))
+        return self._create_filtered([game for game in self.games if game.competition in TROPHY_COMPETITIONS],
+                                     self._new_description('Trophy games'))
 
     @property
     def europe_games(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.competition in EUROPE_COMPETITIONS],
-                                 self._new_description('Europe games'))
+        return self._create_filtered([game for game in self.games if game.competition in EUROPE_COMPETITIONS],
+                                     self._new_description('Europe games'))
 
     @property
     def league_games(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.competition in LEAGUE_COMPETITIONS],
-                                 self._new_description('League games'))
+        return self._create_filtered([game for game in self.games if game.competition in LEAGUE_COMPETITIONS],
+                                     self._new_description('League games'))
 
     @property
     def official_games(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.competition not in NON_OFFICIAL_COMPETITIONS],
-                                 self._new_description('Official games'))
+        return self._create_filtered([game for game in self.games if game.competition not in NON_OFFICIAL_COMPETITIONS],
+                                     self._new_description('Official games'))
 
     @property
     def non_official_games(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.competition in NON_OFFICIAL_COMPETITIONS],
-                                 self._new_description(f'Non-official games'))
+        return self._create_filtered([game for game in self.games if game.competition in NON_OFFICIAL_COMPETITIONS],
+                                     self._new_description(f'Non-official games'))
 
     # endregion
 
@@ -179,35 +177,35 @@ class MaccabiGamesStats:
 
     @property
     def maccabi_wins(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.is_maccabi_win],
-                                 self._new_description('Wins only'))
+        return self._create_filtered([game for game in self.games if game.is_maccabi_win],
+                                     self._new_description('Wins only'))
 
     @property
     def maccabi_ties(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.maccabi_score_diff == 0],
-                                 self._new_description('Ties only'))
+        return self._create_filtered([game for game in self.games if game.maccabi_score_diff == 0],
+                                     self._new_description('Ties only'))
 
     @property
     def maccabi_losses(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.maccabi_score_diff < 0],
-                                 self._new_description('Losses only'))
+        return self._create_filtered([game for game in self.games if game.maccabi_score_diff < 0],
+                                     self._new_description('Losses only'))
 
     @property
     def technical_result_games(self) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.technical_result],
-                                 self._new_description('Technical games'))
+        return self._create_filtered([game for game in self.games if game.technical_result],
+                                     self._new_description('Technical games'))
 
     # endregion
 
     # region date based
 
     def played_before(self, date: Union[datetime.datetime, datetime.date, str]) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.played_before(date)],
-                                 self._new_description(f'Played before: {date}'))
+        return self._create_filtered([game for game in self.games if game.played_before(date)],
+                                     self._new_description(f'Played before: {date}'))
 
     def played_after(self, date: Union[datetime.datetime, datetime.date, str]) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if game.played_after(date)],
-                                 self._new_description(f'Player after: {date}'))
+        return self._create_filtered([game for game in self.games if game.played_after(date)],
+                                     self._new_description(f'Player after: {date}'))
 
     def played_at(self, date: Union[datetime.datetime, datetime.date, str]) -> MaccabiGamesStats:
         if isinstance(date, str):
@@ -215,8 +213,8 @@ class MaccabiGamesStats:
         elif isinstance(date, datetime.datetime):
             date = date.date()  # Leave only year & month & day
 
-        return MaccabiGamesStats([game for game in self.games if game.date.date() == date],
-                                 self._new_description(f'Played at: {date}'))
+        return self._create_filtered([game for game in self.games if game.date.date() == date],
+                                     self._new_description(f'Played at: {date}'))
 
     @property
     def first_game_date(self) -> str:
@@ -234,59 +232,59 @@ class MaccabiGamesStats:
         if isinstance(competition_types, str):
             competition_types = [competition_types]
 
-        return MaccabiGamesStats([game for game in self.games if game.competition in competition_types],
-                                 self._new_description(f'Competitions: {competition_types}'))
+        return self._create_filtered([game for game in self.games if game.competition in competition_types],
+                                     self._new_description(f'Competitions: {competition_types}'))
 
     def get_games_by_stadium(self, stadium_name: str) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if stadium_name == game.stadium],
-                                 self._new_description(f'Stadium: {stadium_name}'))
+        return self._create_filtered([game for game in self.games if stadium_name == game.stadium],
+                                     self._new_description(f'Stadium: {stadium_name}'))
 
     def get_games_against_team(self, team_name: str) -> MaccabiGamesStats:
         # We count the team name as the name when they appear to the game or the name as they have these days
         current_team_name = self._team_names_convertor.find_team_current_name(team_name)
 
-        return MaccabiGamesStats([game for game in self.games if
-                                  current_team_name == game.not_maccabi_team.current_name],
-                                 self._new_description(f'Against team: {team_name}'))
+        return self._create_filtered([game for game in self.games if
+                                      current_team_name == game.not_maccabi_team.current_name],
+                                     self._new_description(f'Against team: {team_name}'))
 
     def get_games_by_coach(self, coach_name: str) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if coach_name == game.maccabi_team.coach],
-                                 self._new_description(f'Coach: {coach_name}'))
+        return self._create_filtered([game for game in self.games if coach_name == game.maccabi_team.coach],
+                                     self._new_description(f'Coach: {coach_name}'))
 
     def get_games_by_referee(self, referee_name: str) -> MaccabiGamesStats:
-        return MaccabiGamesStats([game for game in self.games if referee_name == game.referee],
-                                 self._new_description(f'Referee: {referee_name}'))
+        return self._create_filtered([game for game in self.games if referee_name == game.referee],
+                                     self._new_description(f'Referee: {referee_name}'))
 
     def get_games_by_player_name(self, player_name: str) -> MaccabiGamesStats:
         """
         Returns all the games that this player have any event in, played or at the bench.
         """
-        return MaccabiGamesStats([game for game in self.games
-                                  if player_name in [p.name.strip() for p in game.maccabi_team.players]],
-                                 self._new_description(f'Player in squad: {player_name}'))
+        return self._create_filtered([game for game in self.games
+                                      if player_name in [p.name.strip() for p in game.maccabi_team.players]],
+                                     self._new_description(f'Player in squad: {player_name}'))
 
     def get_games_by_played_player_name(self, player_name: str) -> MaccabiGamesStats:
         """
         Returns all the games that the given players played at.
         """
-        return MaccabiGamesStats([game for game in self.games
-                                  if player_name in [p.name.strip() for p in game.maccabi_team.played_players]],
-                                 self._new_description(f'Played player: {player_name}'))
+        return self._create_filtered([game for game in self.games
+                                      if player_name in [p.name.strip() for p in game.maccabi_team.played_players]],
+                                     self._new_description(f'Played player: {player_name}'))
 
     def get_games_by_season(self, season: str) -> MaccabiGamesStats:
         """
         Return Maccabi games stats object with season games, season may be entered as "1900/01".
         """
-        return MaccabiGamesStats([game for game in self.games if game.season == season],
-                                 self._new_description(f'Season {season}'))
+        return self._create_filtered([game for game in self.games if game.season == season],
+                                     self._new_description(f'Season {season}'))
 
     def get_games_by_day_at_month(self, day: int, month: int) -> MaccabiGamesStats:
         """
         Filter the maccabi games that played at the given day and month
         """
-        return MaccabiGamesStats([game for game in self.games if
-                                  game.date.day == day and game.date.month == month],
-                                 self._new_description(f'Played at DD/MM: {day}/{month}'))
+        return self._create_filtered([game for game in self.games if
+                                      game.date.day == day and game.date.month == month],
+                                     self._new_description(f'Played at DD/MM: {day}/{month}'))
 
     # endregion
 
@@ -300,8 +298,8 @@ class MaccabiGamesStats:
             for player in game.maccabi_team.played_players:
                 players_games[player.name].append(game)
 
-        games_by_player = {player_name: MaccabiGamesStats(players_games[player_name],
-                                                          self._new_description(f'Player games: {player_name}'))
+        games_by_player = {player_name: self._create_filtered(players_games[player_name],
+                                                              self._new_description(f'Player games: {player_name}'))
                            for player_name in players_games.keys()}
 
         # Allow to return an empty list for unknown players
@@ -326,15 +324,15 @@ class MaccabiGamesStats:
         games_by_player_and_team = defaultdict(lambda: defaultdict(lambda: MaccabiGamesStats([])))
         for player_name, teams_mapping in players_to_teams_to_games_mapping.items():
             for team_name, specific_player_and_team_games in teams_mapping.items():
-                current_combination_games = MaccabiGamesStats(specific_player_and_team_games,
-                                                              f'Players {player_name} and Team: {team_name} games')
+                current_combination_games = self._create_filtered(specific_player_and_team_games,
+                                                                  f'Players {player_name} and Team: {team_name} games')
                 games_by_player_and_team[player_name][team_name] = current_combination_games
 
         # Allow to return an empty list for unknown players, same default dict as above but with MaccabiGamesStats
         return defaultdict(lambda: defaultdict(lambda: MaccabiGamesStats([])), games_by_player_and_team)
 
     def create_maccabi_stats_from_games(self, games: List[GameData]) -> MaccabiGamesStats:
-        return MaccabiGamesStats(games, description=self.description)
+        return self._create_filtered(games, self.description)
 
     @property
     def points(self):

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -83,7 +83,7 @@ class MaccabiGamesStats:
             old_version = state.get('version', 'unknown')
             raise RuntimeError(
                 f"This pickled MaccabiGamesStats (version {old_version}) does not contain players_data. "
-                f"Please re-run run_maccabipedia_source() with maccabistats >= 2.54 to create a new pickle."
+                f"Please re-run run_maccabipedia_source() with maccabistats >= 2.60 to create a new pickle."
             )
         self.__dict__.update(state)
 

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -47,13 +47,13 @@ class MaccabiGamesStats:
     _DEFAULT_DESCRIPTION = 'All games'
 
     def __init__(self, games: List[GameData], description: str = None,
-                 maccabipedia_players: MaccabiPediaPlayers = None) -> None:
+                 players_data: MaccabiPediaPlayers = None) -> None:
         self.games: List[GameData] = sorted(games, key=lambda g: g.date)  # Sort the games by date
         self.description = description or self._DEFAULT_DESCRIPTION
 
         # Players data is stored so it's pickled with the games (no internet needed on load).
         # Callers that need players data should explicitly pass it.
-        self.maccabipedia_players = maccabipedia_players
+        self.players_data = players_data
 
         self.coaches = MaccabiGamesCoachesStats(self)
         self.players = MaccabiGamesPlayersStats(self)
@@ -83,7 +83,7 @@ class MaccabiGamesStats:
 
     def create_maccabi_games_stats_with_filtered_games(self, games: List[GameData], description: str) -> MaccabiGamesStats:
         """Create a filtered MaccabiGamesStats that inherits the players data."""
-        return MaccabiGamesStats(games, description, maccabipedia_players=self.maccabipedia_players)
+        return MaccabiGamesStats(games, description, players_data=self.players_data)
 
     # region home_away
 

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -78,6 +78,15 @@ class MaccabiGamesStats:
 
         self.version = maccabistats_version
 
+    def __setstate__(self, state):
+        if 'players_data' not in state:
+            old_version = state.get('version', 'unknown')
+            raise RuntimeError(
+                f"This pickled MaccabiGamesStats (version {old_version}) does not contain players_data. "
+                f"Please re-run run_maccabipedia_source() with maccabistats >= 2.54 to create a new pickle."
+            )
+        self.__dict__.update(state)
+
     def create_maccabi_games_stats_with_filtered_games(self, games: List[GameData], description: str) -> MaccabiGamesStats:
         """Create a filtered MaccabiGamesStats that inherits the players data."""
         return MaccabiGamesStats(games, description, players_data=self.players_data)

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -57,7 +57,12 @@ class MaccabiGamesStats:
             self.maccabipedia_players = maccabipedia_players
         elif self.games:
             logger.info("No cached players data provided, crawling from MaccabiPedia (requires internet)")
-            self.maccabipedia_players = MaccabiPediaPlayers.get_players_data()
+            try:
+                self.maccabipedia_players = MaccabiPediaPlayers.get_players_data()
+            except Exception:
+                logger.warning("Failed to crawl players data — player-related stats will be unavailable",
+                               exc_info=True)
+                self.maccabipedia_players = None
         else:
             self.maccabipedia_players = None
 

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -51,20 +51,9 @@ class MaccabiGamesStats:
         self.games: List[GameData] = sorted(games, key=lambda g: g.date)  # Sort the games by date
         self.description = description or self._DEFAULT_DESCRIPTION
 
-        # Store players data so it's pickled with the games (no internet needed on load).
-        # Only crawl when not provided and there are games to process.
-        if maccabipedia_players is not None:
-            self.maccabipedia_players = maccabipedia_players
-        elif self.games:
-            logger.info("No cached players data provided, crawling from MaccabiPedia (requires internet)")
-            try:
-                self.maccabipedia_players = MaccabiPediaPlayers.get_players_data()
-            except Exception:
-                logger.warning("Failed to crawl players data — player-related stats will be unavailable",
-                               exc_info=True)
-                self.maccabipedia_players = None
-        else:
-            self.maccabipedia_players = None
+        # Players data is stored so it's pickled with the games (no internet needed on load).
+        # Callers that need players data should explicitly pass it.
+        self.maccabipedia_players = maccabipedia_players
 
         self.coaches = MaccabiGamesCoachesStats(self)
         self.players = MaccabiGamesPlayersStats(self)

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -50,9 +50,6 @@ class MaccabiGamesStats:
                  players_data: MaccabiPediaPlayers = None) -> None:
         self.games: List[GameData] = sorted(games, key=lambda g: g.date)  # Sort the games by date
         self.description = description or self._DEFAULT_DESCRIPTION
-
-        # Players data is stored so it's pickled with the games (no internet needed on load).
-        # Callers that need players data should explicitly pass it.
         self.players_data = players_data
 
         self.coaches = MaccabiGamesCoachesStats(self)
@@ -298,7 +295,8 @@ class MaccabiGamesStats:
                            for player_name in players_games.keys()}
 
         # Allow to return an empty list for unknown players
-        return defaultdict(lambda: MaccabiGamesStats([]), games_by_player)
+        players_data = self.players_data
+        return defaultdict(lambda: MaccabiGamesStats([], players_data=players_data), games_by_player)
 
     def played_games_by_player_and_team(self) -> Dict[str, DefaultDict[str, MaccabiGamesStats]]:
         """
@@ -316,7 +314,8 @@ class MaccabiGamesStats:
                 # adds at [player][team].append(game)
                 players_to_teams_to_games_mapping[player.name][game.not_maccabi_team.current_name].append(game)
 
-        games_by_player_and_team = defaultdict(lambda: defaultdict(lambda: MaccabiGamesStats([])))
+        players_data = self.players_data
+        games_by_player_and_team = defaultdict(lambda: defaultdict(lambda: MaccabiGamesStats([], players_data=players_data)))
         for player_name, teams_mapping in players_to_teams_to_games_mapping.items():
             for team_name, specific_player_and_team_games in teams_mapping.items():
                 current_combination_games = self.create_maccabi_games_stats_with_filtered_games(specific_player_and_team_games,
@@ -324,7 +323,7 @@ class MaccabiGamesStats:
                 games_by_player_and_team[player_name][team_name] = current_combination_games
 
         # Allow to return an empty list for unknown players, same default dict as above but with MaccabiGamesStats
-        return defaultdict(lambda: defaultdict(lambda: MaccabiGamesStats([])), games_by_player_and_team)
+        return defaultdict(lambda: defaultdict(lambda: MaccabiGamesStats([], players_data=players_data)), games_by_player_and_team)
 
     def create_maccabi_stats_from_games(self, games: List[GameData]) -> MaccabiGamesStats:
         return self.create_maccabi_games_stats_with_filtered_games(games, self.description)

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -9,6 +9,7 @@ from typing import List, Union, Dict, Any, DefaultDict
 
 from dateutil.parser import parse as datetime_parser
 
+from maccabistats.maccabipedia.players import MaccabiPediaPlayers
 from maccabistats.models.game_data import GameData
 from maccabistats.models.player import Player
 from maccabistats.stats.averages import MaccabiGamesAverageStats
@@ -74,6 +75,22 @@ class MaccabiGamesStats:
         self._team_names_convertor = TeamNamesConvertor(self)
 
         self.version = maccabistats_version
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Include players data in the pickle so loading doesn't require internet
+        players_instance = MaccabiPediaPlayers._instance
+        if players_instance is not None:
+            state['_players_data_cache'] = players_instance.raw_players_data
+        return state
+
+    def __setstate__(self, state):
+        # Restore players data singleton before reconstructing stats objects
+        players_data_cache = state.pop('_players_data_cache', None)
+        if players_data_cache is not None and MaccabiPediaPlayers._instance is None:
+            MaccabiPediaPlayers.load_from_cache(players_data_cache)
+
+        self.__dict__.update(state)
 
     # region home_away
 

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -47,18 +47,19 @@ class MaccabiGamesStats:
     _DEFAULT_DESCRIPTION = 'All games'
 
     def __init__(self, games: List[GameData], description: str = None,
-                 _maccabipedia_players: MaccabiPediaPlayers = None) -> None:
+                 maccabipedia_players: MaccabiPediaPlayers = None) -> None:
         self.games: List[GameData] = sorted(games, key=lambda g: g.date)  # Sort the games by date
         self.description = description or self._DEFAULT_DESCRIPTION
 
         # Store players data so it's pickled with the games (no internet needed on load).
         # Only crawl when not provided and there are games to process.
-        if _maccabipedia_players is not None:
-            self._maccabipedia_players = _maccabipedia_players
+        if maccabipedia_players is not None:
+            self.maccabipedia_players = maccabipedia_players
         elif self.games:
-            self._maccabipedia_players = MaccabiPediaPlayers.get_players_data()
+            logger.info("No cached players data provided, crawling from MaccabiPedia (requires internet)")
+            self.maccabipedia_players = MaccabiPediaPlayers.get_players_data()
         else:
-            self._maccabipedia_players = None
+            self.maccabipedia_players = None
 
         self.coaches = MaccabiGamesCoachesStats(self)
         self.players = MaccabiGamesPlayersStats(self)
@@ -88,7 +89,7 @@ class MaccabiGamesStats:
 
     def _create_filtered(self, games: List[GameData], description: str) -> MaccabiGamesStats:
         """Create a filtered MaccabiGamesStats that inherits the players data."""
-        return MaccabiGamesStats(games, description, _maccabipedia_players=self._maccabipedia_players)
+        return MaccabiGamesStats(games, description, maccabipedia_players=self.maccabipedia_players)
 
     # region home_away
 

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -92,7 +92,7 @@ class MaccabiGamesStats:
 
         self.version = maccabistats_version
 
-    def _create_filtered(self, games: List[GameData], description: str) -> MaccabiGamesStats:
+    def create_maccabi_games_stats_with_filtered_games(self, games: List[GameData], description: str) -> MaccabiGamesStats:
         """Create a filtered MaccabiGamesStats that inherits the players data."""
         return MaccabiGamesStats(games, description, maccabipedia_players=self.maccabipedia_players)
 
@@ -100,12 +100,12 @@ class MaccabiGamesStats:
 
     @property
     def home_games(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.is_maccabi_home_team],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.is_maccabi_home_team],
                                      self._new_description('Home games'))
 
     @property
     def away_games(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if not game.is_maccabi_home_team],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if not game.is_maccabi_home_team],
                                      self._new_description('Away games'))
 
     # endregion
@@ -114,27 +114,27 @@ class MaccabiGamesStats:
 
     @property
     def trophy_games(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.competition in TROPHY_COMPETITIONS],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.competition in TROPHY_COMPETITIONS],
                                      self._new_description('Trophy games'))
 
     @property
     def europe_games(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.competition in EUROPE_COMPETITIONS],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.competition in EUROPE_COMPETITIONS],
                                      self._new_description('Europe games'))
 
     @property
     def league_games(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.competition in LEAGUE_COMPETITIONS],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.competition in LEAGUE_COMPETITIONS],
                                      self._new_description('League games'))
 
     @property
     def official_games(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.competition not in NON_OFFICIAL_COMPETITIONS],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.competition not in NON_OFFICIAL_COMPETITIONS],
                                      self._new_description('Official games'))
 
     @property
     def non_official_games(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.competition in NON_OFFICIAL_COMPETITIONS],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.competition in NON_OFFICIAL_COMPETITIONS],
                                      self._new_description(f'Non-official games'))
 
     # endregion
@@ -183,22 +183,22 @@ class MaccabiGamesStats:
 
     @property
     def maccabi_wins(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.is_maccabi_win],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.is_maccabi_win],
                                      self._new_description('Wins only'))
 
     @property
     def maccabi_ties(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.maccabi_score_diff == 0],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.maccabi_score_diff == 0],
                                      self._new_description('Ties only'))
 
     @property
     def maccabi_losses(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.maccabi_score_diff < 0],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.maccabi_score_diff < 0],
                                      self._new_description('Losses only'))
 
     @property
     def technical_result_games(self) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.technical_result],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.technical_result],
                                      self._new_description('Technical games'))
 
     # endregion
@@ -206,11 +206,11 @@ class MaccabiGamesStats:
     # region date based
 
     def played_before(self, date: Union[datetime.datetime, datetime.date, str]) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.played_before(date)],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.played_before(date)],
                                      self._new_description(f'Played before: {date}'))
 
     def played_after(self, date: Union[datetime.datetime, datetime.date, str]) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if game.played_after(date)],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.played_after(date)],
                                      self._new_description(f'Player after: {date}'))
 
     def played_at(self, date: Union[datetime.datetime, datetime.date, str]) -> MaccabiGamesStats:
@@ -219,7 +219,7 @@ class MaccabiGamesStats:
         elif isinstance(date, datetime.datetime):
             date = date.date()  # Leave only year & month & day
 
-        return self._create_filtered([game for game in self.games if game.date.date() == date],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.date.date() == date],
                                      self._new_description(f'Played at: {date}'))
 
     @property
@@ -238,34 +238,34 @@ class MaccabiGamesStats:
         if isinstance(competition_types, str):
             competition_types = [competition_types]
 
-        return self._create_filtered([game for game in self.games if game.competition in competition_types],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.competition in competition_types],
                                      self._new_description(f'Competitions: {competition_types}'))
 
     def get_games_by_stadium(self, stadium_name: str) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if stadium_name == game.stadium],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if stadium_name == game.stadium],
                                      self._new_description(f'Stadium: {stadium_name}'))
 
     def get_games_against_team(self, team_name: str) -> MaccabiGamesStats:
         # We count the team name as the name when they appear to the game or the name as they have these days
         current_team_name = self._team_names_convertor.find_team_current_name(team_name)
 
-        return self._create_filtered([game for game in self.games if
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if
                                       current_team_name == game.not_maccabi_team.current_name],
                                      self._new_description(f'Against team: {team_name}'))
 
     def get_games_by_coach(self, coach_name: str) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if coach_name == game.maccabi_team.coach],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if coach_name == game.maccabi_team.coach],
                                      self._new_description(f'Coach: {coach_name}'))
 
     def get_games_by_referee(self, referee_name: str) -> MaccabiGamesStats:
-        return self._create_filtered([game for game in self.games if referee_name == game.referee],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if referee_name == game.referee],
                                      self._new_description(f'Referee: {referee_name}'))
 
     def get_games_by_player_name(self, player_name: str) -> MaccabiGamesStats:
         """
         Returns all the games that this player have any event in, played or at the bench.
         """
-        return self._create_filtered([game for game in self.games
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games
                                       if player_name in [p.name.strip() for p in game.maccabi_team.players]],
                                      self._new_description(f'Player in squad: {player_name}'))
 
@@ -273,7 +273,7 @@ class MaccabiGamesStats:
         """
         Returns all the games that the given players played at.
         """
-        return self._create_filtered([game for game in self.games
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games
                                       if player_name in [p.name.strip() for p in game.maccabi_team.played_players]],
                                      self._new_description(f'Played player: {player_name}'))
 
@@ -281,14 +281,14 @@ class MaccabiGamesStats:
         """
         Return Maccabi games stats object with season games, season may be entered as "1900/01".
         """
-        return self._create_filtered([game for game in self.games if game.season == season],
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if game.season == season],
                                      self._new_description(f'Season {season}'))
 
     def get_games_by_day_at_month(self, day: int, month: int) -> MaccabiGamesStats:
         """
         Filter the maccabi games that played at the given day and month
         """
-        return self._create_filtered([game for game in self.games if
+        return self.create_maccabi_games_stats_with_filtered_games([game for game in self.games if
                                       game.date.day == day and game.date.month == month],
                                      self._new_description(f'Played at DD/MM: {day}/{month}'))
 
@@ -304,7 +304,7 @@ class MaccabiGamesStats:
             for player in game.maccabi_team.played_players:
                 players_games[player.name].append(game)
 
-        games_by_player = {player_name: self._create_filtered(players_games[player_name],
+        games_by_player = {player_name: self.create_maccabi_games_stats_with_filtered_games(players_games[player_name],
                                                               self._new_description(f'Player games: {player_name}'))
                            for player_name in players_games.keys()}
 
@@ -330,7 +330,7 @@ class MaccabiGamesStats:
         games_by_player_and_team = defaultdict(lambda: defaultdict(lambda: MaccabiGamesStats([])))
         for player_name, teams_mapping in players_to_teams_to_games_mapping.items():
             for team_name, specific_player_and_team_games in teams_mapping.items():
-                current_combination_games = self._create_filtered(specific_player_and_team_games,
+                current_combination_games = self.create_maccabi_games_stats_with_filtered_games(specific_player_and_team_games,
                                                                   f'Players {player_name} and Team: {team_name} games')
                 games_by_player_and_team[player_name][team_name] = current_combination_games
 
@@ -338,7 +338,7 @@ class MaccabiGamesStats:
         return defaultdict(lambda: defaultdict(lambda: MaccabiGamesStats([])), games_by_player_and_team)
 
     def create_maccabi_stats_from_games(self, games: List[GameData]) -> MaccabiGamesStats:
-        return self._create_filtered(games, self.description)
+        return self.create_maccabi_games_stats_with_filtered_games(games, self.description)
 
     @property
     def points(self):

--- a/packages/maccabistats/src/maccabistats/stats/players_categories.py
+++ b/packages/maccabistats/src/maccabistats/stats/players_categories.py
@@ -23,6 +23,8 @@ class MaccabiGamesPlayersCategoriesStats(object):
         self.maccabi_games_stats = maccabi_games_stats
         self.games = maccabi_games_stats.games
         players = maccabi_games_stats.maccabipedia_players
+        if players is None and maccabi_games_stats.games:
+            logger.warning("Players data is missing — player categories stats will return empty results")
         self.maccabi_home_players_names = players.home_players if players else set()
 
     def _home_players_events(self, game_events_callable) -> Tuple[int, int]:

--- a/packages/maccabistats/src/maccabistats/stats/players_categories.py
+++ b/packages/maccabistats/src/maccabistats/stats/players_categories.py
@@ -5,8 +5,6 @@ from collections import Counter
 from sys import maxsize
 from typing import Tuple, TYPE_CHECKING
 
-from maccabistats.maccabipedia.players import MaccabiPediaPlayers
-
 if TYPE_CHECKING:
     from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
 
@@ -24,7 +22,8 @@ class MaccabiGamesPlayersCategoriesStats(object):
     def __init__(self, maccabi_games_stats: MaccabiGamesStats):
         self.maccabi_games_stats = maccabi_games_stats
         self.games = maccabi_games_stats.games
-        self.maccabi_home_players_names = MaccabiPediaPlayers.get_players_data().home_players
+        players = maccabi_games_stats._maccabipedia_players
+        self.maccabi_home_players_names = players.home_players if players else set()
 
     def _home_players_events(self, game_events_callable) -> Tuple[int, int]:
         """

--- a/packages/maccabistats/src/maccabistats/stats/players_categories.py
+++ b/packages/maccabistats/src/maccabistats/stats/players_categories.py
@@ -22,10 +22,7 @@ class MaccabiGamesPlayersCategoriesStats(object):
     def __init__(self, maccabi_games_stats: MaccabiGamesStats):
         self.maccabi_games_stats = maccabi_games_stats
         self.games = maccabi_games_stats.games
-        players = maccabi_games_stats.players_data
-        if players is None and maccabi_games_stats.games:
-            logger.warning("Players data is missing — player categories stats will return empty results")
-        self.maccabi_home_players_names = players.home_players if players else set()
+        self.maccabi_home_players_names = maccabi_games_stats.players_data.home_players
 
     def _home_players_events(self, game_events_callable) -> Tuple[int, int]:
         """

--- a/packages/maccabistats/src/maccabistats/stats/players_categories.py
+++ b/packages/maccabistats/src/maccabistats/stats/players_categories.py
@@ -22,7 +22,7 @@ class MaccabiGamesPlayersCategoriesStats(object):
     def __init__(self, maccabi_games_stats: MaccabiGamesStats):
         self.maccabi_games_stats = maccabi_games_stats
         self.games = maccabi_games_stats.games
-        players = maccabi_games_stats._maccabipedia_players
+        players = maccabi_games_stats.maccabipedia_players
         self.maccabi_home_players_names = players.home_players if players else set()
 
     def _home_players_events(self, game_events_callable) -> Tuple[int, int]:

--- a/packages/maccabistats/src/maccabistats/stats/players_categories.py
+++ b/packages/maccabistats/src/maccabistats/stats/players_categories.py
@@ -22,7 +22,7 @@ class MaccabiGamesPlayersCategoriesStats(object):
     def __init__(self, maccabi_games_stats: MaccabiGamesStats):
         self.maccabi_games_stats = maccabi_games_stats
         self.games = maccabi_games_stats.games
-        players = maccabi_games_stats.maccabipedia_players
+        players = maccabi_games_stats.players_data
         if players is None and maccabi_games_stats.games:
             logger.warning("Players data is missing — player categories stats will return empty results")
         self.maccabi_home_players_names = players.home_players if players else set()

--- a/packages/maccabistats/src/maccabistats/stats/players_special_games.py
+++ b/packages/maccabistats/src/maccabistats/stats/players_special_games.py
@@ -40,7 +40,8 @@ class MaccabiGamesPlayersSpecialGamesStats(object):
     def __init__(self, maccabi_games_stats: MaccabiGamesStats):
         self.maccabi_games_stats = maccabi_games_stats
         self.games = maccabi_games_stats.games
-        self.players_birth_dates = MaccabiPediaPlayers.get_players_data().players_dates
+        players = maccabi_games_stats._maccabipedia_players
+        self.players_birth_dates = players.players_dates if players else {}
 
     def _players_by_game_condition_ordered_by_age(self,
                                                   player_game_condition: Callable[[GameData, str], bool],

--- a/packages/maccabistats/src/maccabistats/stats/players_special_games.py
+++ b/packages/maccabistats/src/maccabistats/stats/players_special_games.py
@@ -40,7 +40,7 @@ class MaccabiGamesPlayersSpecialGamesStats(object):
     def __init__(self, maccabi_games_stats: MaccabiGamesStats):
         self.maccabi_games_stats = maccabi_games_stats
         self.games = maccabi_games_stats.games
-        players = maccabi_games_stats.maccabipedia_players
+        players = maccabi_games_stats.players_data
         if players is None and maccabi_games_stats.games:
             logger.warning("Players data is missing — player special games stats will return empty results")
         self.players_birth_dates = players.players_dates if players else {}

--- a/packages/maccabistats/src/maccabistats/stats/players_special_games.py
+++ b/packages/maccabistats/src/maccabistats/stats/players_special_games.py
@@ -41,6 +41,8 @@ class MaccabiGamesPlayersSpecialGamesStats(object):
         self.maccabi_games_stats = maccabi_games_stats
         self.games = maccabi_games_stats.games
         players = maccabi_games_stats.maccabipedia_players
+        if players is None and maccabi_games_stats.games:
+            logger.warning("Players data is missing — player special games stats will return empty results")
         self.players_birth_dates = players.players_dates if players else {}
 
     def _players_by_game_condition_ordered_by_age(self,

--- a/packages/maccabistats/src/maccabistats/stats/players_special_games.py
+++ b/packages/maccabistats/src/maccabistats/stats/players_special_games.py
@@ -40,10 +40,7 @@ class MaccabiGamesPlayersSpecialGamesStats(object):
     def __init__(self, maccabi_games_stats: MaccabiGamesStats):
         self.maccabi_games_stats = maccabi_games_stats
         self.games = maccabi_games_stats.games
-        players = maccabi_games_stats.players_data
-        if players is None and maccabi_games_stats.games:
-            logger.warning("Players data is missing — player special games stats will return empty results")
-        self.players_birth_dates = players.players_dates if players else {}
+        self.players_birth_dates = maccabi_games_stats.players_data.players_dates
 
     def _players_by_game_condition_ordered_by_age(self,
                                                   player_game_condition: Callable[[GameData, str], bool],

--- a/packages/maccabistats/src/maccabistats/stats/players_special_games.py
+++ b/packages/maccabistats/src/maccabistats/stats/players_special_games.py
@@ -40,7 +40,7 @@ class MaccabiGamesPlayersSpecialGamesStats(object):
     def __init__(self, maccabi_games_stats: MaccabiGamesStats):
         self.maccabi_games_stats = maccabi_games_stats
         self.games = maccabi_games_stats.games
-        players = maccabi_games_stats._maccabipedia_players
+        players = maccabi_games_stats.maccabipedia_players
         self.players_birth_dates = players.players_dates if players else {}
 
     def _players_by_game_condition_ordered_by_age(self,

--- a/packages/maccabistats/src/maccabistats/stats/serialized_games.py
+++ b/packages/maccabistats/src/maccabistats/stats/serialized_games.py
@@ -23,7 +23,7 @@ def get_maccabi_stats_as_newest_wrapper(file_name: Optional[str] = None) -> Macc
     """
     loaded = get_maccabi_stats(file_name)
     return MaccabiGamesStats(loaded.games,
-                             _maccabipedia_players=getattr(loaded, '_maccabipedia_players', None))
+                             maccabipedia_players=getattr(loaded, 'maccabipedia_players', None))
 
 
 def get_maccabi_stats(file_name: Optional[str] = None) -> MaccabiGamesStats:

--- a/packages/maccabistats/src/maccabistats/stats/serialized_games.py
+++ b/packages/maccabistats/src/maccabistats/stats/serialized_games.py
@@ -23,7 +23,7 @@ def get_maccabi_stats_as_newest_wrapper(file_name: Optional[str] = None) -> Macc
     """
     loaded = get_maccabi_stats(file_name)
     return MaccabiGamesStats(loaded.games,
-                             maccabipedia_players=getattr(loaded, 'maccabipedia_players', None))
+                             players_data=loaded.players_data)
 
 
 def get_maccabi_stats(file_name: Optional[str] = None) -> MaccabiGamesStats:

--- a/packages/maccabistats/src/maccabistats/stats/serialized_games.py
+++ b/packages/maccabistats/src/maccabistats/stats/serialized_games.py
@@ -21,8 +21,9 @@ def get_maccabi_stats_as_newest_wrapper(file_name: Optional[str] = None) -> Macc
     """"
     Returns the serialized file_name cast to the latest MaccabiGamesStats object, which means that newer functions can be used.
     """
-
-    return MaccabiGamesStats(get_maccabi_stats(file_name).games)
+    loaded = get_maccabi_stats(file_name)
+    return MaccabiGamesStats(loaded.games,
+                             _maccabipedia_players=getattr(loaded, '_maccabipedia_players', None))
 
 
 def get_maccabi_stats(file_name: Optional[str] = None) -> MaccabiGamesStats:

--- a/packages/maccabistats/src/maccabistats/version.py
+++ b/packages/maccabistats/src/maccabistats/version.py
@@ -1,1 +1,1 @@
-version = "2.54"
+version = "2.60"

--- a/packages/maccabistats/src/maccabistats/version.py
+++ b/packages/maccabistats/src/maccabistats/version.py
@@ -1,1 +1,1 @@
-version = "2.53"
+version = "2.54"

--- a/packages/maccabistats/tests/test_players_data_pickle.py
+++ b/packages/maccabistats/tests/test_players_data_pickle.py
@@ -1,6 +1,7 @@
 """Test that MaccabiGamesStats includes players data in pickle for offline loading."""
 
 import pickle
+from collections import defaultdict
 from datetime import datetime
 
 import pytest
@@ -40,8 +41,14 @@ def _make_game(date: datetime) -> GameData:
 
 
 def _make_players_instance():
-    """Create a MaccabiPediaPlayers instance with test data."""
-    return MaccabiPediaPlayers.load_from_cache(_TEST_PLAYERS_DATA)
+    """Create a MaccabiPediaPlayers instance with test data (without network)."""
+    instance = object.__new__(MaccabiPediaPlayers)
+    instance._players_data = _TEST_PLAYERS_DATA
+    instance.players_dates = defaultdict(MaccabiPediaPlayers.default_birth_day_value,
+                                         {name: p.birth_date for name, p in _TEST_PLAYERS_DATA.items()})
+    instance.home_players = {p.name for p in _TEST_PLAYERS_DATA.values() if p.is_home_player}
+    MaccabiPediaPlayers._instance = instance
+    return instance
 
 
 # --- Core feature tests ---
@@ -215,14 +222,3 @@ def test_crawl_failure_degrades_gracefully(monkeypatch):
     # Player stats should degrade to empty
     assert stats.players_categories.maccabi_home_players_names == set()
     assert stats.maccabipedia_players is None
-
-
-# --- load_from_cache ---
-
-
-def test_load_from_cache_returns_instance():
-    """load_from_cache should return the created instance."""
-    instance = MaccabiPediaPlayers.load_from_cache(_TEST_PLAYERS_DATA)
-    assert instance is not None
-    assert instance is MaccabiPediaPlayers._instance
-    assert instance.home_players == {"שחקן א"}

--- a/packages/maccabistats/tests/test_players_data_pickle.py
+++ b/packages/maccabistats/tests/test_players_data_pickle.py
@@ -58,9 +58,9 @@ def test_players_data_stored_as_attribute():
     """Players data should be stored as a regular attribute on MaccabiGamesStats."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
-    stats = MaccabiGamesStats(games, maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, players_data=players)
 
-    assert stats.maccabipedia_players is players
+    assert stats.players_data is players
     assert stats.players_categories.maccabi_home_players_names == {"שחקן א"}
 
 
@@ -68,22 +68,22 @@ def test_pickle_roundtrip_preserves_players_data():
     """Pickling and unpickling should preserve the players data without crawling."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
-    stats = MaccabiGamesStats(games, maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, players_data=players)
 
     pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
 
     restored = pickle.loads(pickled)
-    assert restored.maccabipedia_players is not None
-    assert restored.maccabipedia_players.home_players == {"שחקן א"}
-    assert restored.maccabipedia_players.players_dates["שחקן ב"] == datetime(1995, 6, 15)
+    assert restored.players_data is not None
+    assert restored.players_data.home_players == {"שחקן א"}
+    assert restored.players_data.players_dates["שחקן ב"] == datetime(1995, 6, 15)
 
 
 def test_filtered_stats_inherit_players_data(monkeypatch):
     """Filter properties (e.g. home_games) should inherit players data without crawling."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1)), _make_game(datetime(2024, 10, 1))]
-    stats = MaccabiGamesStats(games, maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, players_data=players)
 
     monkeypatch.setattr(
         MaccabiPediaPlayers, '_crawl_players_data',
@@ -92,7 +92,7 @@ def test_filtered_stats_inherit_players_data(monkeypatch):
     MaccabiPediaPlayers._instance = None
 
     filtered = stats.maccabi_wins
-    assert filtered.maccabipedia_players is players
+    assert filtered.players_data is players
     assert filtered.players_categories.maccabi_home_players_names == {"שחקן א"}
 
 
@@ -100,7 +100,7 @@ def test_unpickle_then_filter_works_offline(monkeypatch):
     """After unpickling, creating filtered stats should work without internet."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1)), _make_game(datetime(2024, 10, 1))]
-    stats = MaccabiGamesStats(games, maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, players_data=players)
 
     pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
@@ -111,7 +111,7 @@ def test_unpickle_then_filter_works_offline(monkeypatch):
     )
 
     restored = pickle.loads(pickled)
-    filtered = MaccabiGamesStats(restored.games, maccabipedia_players=restored.maccabipedia_players)
+    filtered = MaccabiGamesStats(restored.games, players_data=restored.players_data)
     assert filtered.players_categories.maccabi_home_players_names == {"שחקן א"}
 
 
@@ -124,32 +124,32 @@ def test_empty_games_does_not_crawl(monkeypatch):
     MaccabiPediaPlayers._instance = None
 
     stats = MaccabiGamesStats([])
-    assert stats.maccabipedia_players is None
+    assert stats.players_data is None
 
 
 # --- Backward compatibility ---
 
 
 def test_old_pickle_without_players_data_has_none():
-    """Old pickles without maccabipedia_players result in None — no implicit crawl."""
+    """Old pickles without players_data result in None — no implicit crawl."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
-    stats = MaccabiGamesStats(games, maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, players_data=players)
 
     # Simulate an old pickle by removing the attribute before pickling
-    del stats.__dict__['maccabipedia_players']
+    del stats.__dict__['players_data']
     pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
 
     restored = pickle.loads(pickled)
-    assert not hasattr(restored, 'maccabipedia_players')
+    assert not hasattr(restored, 'players_data')
 
     # Wrapping in new MaccabiGamesStats with getattr — gets None, stays None
     wrapper = MaccabiGamesStats(
         restored.games,
-        maccabipedia_players=getattr(restored, 'maccabipedia_players', None),
+        players_data=getattr(restored, 'players_data', None),
     )
-    assert wrapper.maccabipedia_players is None
+    assert wrapper.players_data is None
     # Non-player stats still work
     assert len(wrapper) == 1
 
@@ -158,10 +158,10 @@ def test_old_pickle_without_players_data_has_none():
 
 
 def test_players_special_games_uses_attribute():
-    """players_special_games should get birth dates from the maccabipedia_players attribute."""
+    """players_special_games should get birth dates from the players_data attribute."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
-    stats = MaccabiGamesStats(games, maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, players_data=players)
 
     assert stats.players_special_games.players_birth_dates["שחקן א"] == datetime(2000, 1, 1)
     assert stats.players_special_games.players_birth_dates["שחקן ב"] == datetime(1995, 6, 15)
@@ -174,7 +174,7 @@ def test_filter_chain_preserves_players_data(monkeypatch):
     """Multi-level filter chains should preserve players data throughout."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1)), _make_game(datetime(2024, 10, 1))]
-    stats = MaccabiGamesStats(games, maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, players_data=players)
 
     monkeypatch.setattr(
         MaccabiPediaPlayers, '_crawl_players_data',
@@ -184,7 +184,7 @@ def test_filter_chain_preserves_players_data(monkeypatch):
 
     # Chain: home_games → maccabi_wins → players_categories
     chained = stats.home_games.maccabi_wins
-    assert chained.maccabipedia_players is players
+    assert chained.players_data is players
     assert chained.players_categories.maccabi_home_players_names == {"שחקן א"}
     assert chained.players_special_games.players_birth_dates["שחקן א"] == datetime(2000, 1, 1)
 
@@ -193,7 +193,7 @@ def test_filter_chain_preserves_players_data(monkeypatch):
 
 
 def test_no_implicit_crawl_when_players_not_provided():
-    """Creating MaccabiGamesStats without maccabipedia_players should NOT crawl."""
+    """Creating MaccabiGamesStats without players_data should NOT crawl."""
     games = [_make_game(datetime(2024, 9, 1))]
     stats = MaccabiGamesStats(games)
 
@@ -202,5 +202,5 @@ def test_no_implicit_crawl_when_players_not_provided():
     assert stats.results.wins_count == 1
 
     # Player stats degrade to empty — no implicit network call
-    assert stats.maccabipedia_players is None
+    assert stats.players_data is None
     assert stats.players_categories.maccabi_home_players_names == set()

--- a/packages/maccabistats/tests/test_players_data_pickle.py
+++ b/packages/maccabistats/tests/test_players_data_pickle.py
@@ -115,23 +115,19 @@ def test_unpickle_then_filter_works_offline(monkeypatch):
     assert filtered.players_categories.maccabi_home_players_names == {"שחקן א"}
 
 
-def test_empty_games_does_not_crawl(monkeypatch):
-    """Creating MaccabiGamesStats with empty games should not trigger crawling."""
-    monkeypatch.setattr(
-        MaccabiPediaPlayers, '_crawl_players_data',
-        staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("Should not crawl!"))),
-    )
-    MaccabiPediaPlayers._instance = None
-
-    stats = MaccabiGamesStats([])
-    assert stats.players_data is None
+def test_empty_games_works_with_players_data():
+    """Creating MaccabiGamesStats with empty games and players data should work."""
+    players = _make_players_instance()
+    stats = MaccabiGamesStats([], players_data=players)
+    assert len(stats) == 0
+    assert stats.players_data is players
 
 
 # --- Backward compatibility ---
 
 
-def test_old_pickle_without_players_data_has_none():
-    """Old pickles without players_data result in None — no implicit crawl."""
+def test_old_pickle_without_players_data_fails_loudly():
+    """Old pickles without players_data should fail with AttributeError."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
     stats = MaccabiGamesStats(games, players_data=players)
@@ -142,16 +138,8 @@ def test_old_pickle_without_players_data_has_none():
     MaccabiPediaPlayers._instance = None
 
     restored = pickle.loads(pickled)
-    assert not hasattr(restored, 'players_data')
-
-    # Wrapping in new MaccabiGamesStats with getattr — gets None, stays None
-    wrapper = MaccabiGamesStats(
-        restored.games,
-        players_data=getattr(restored, 'players_data', None),
-    )
-    assert wrapper.players_data is None
-    # Non-player stats still work
-    assert len(wrapper) == 1
+    with pytest.raises(AttributeError):
+        _ = restored.players_data
 
 
 # --- players_special_games ---
@@ -189,18 +177,11 @@ def test_filter_chain_preserves_players_data(monkeypatch):
     assert chained.players_special_games.players_birth_dates["שחקן א"] == datetime(2000, 1, 1)
 
 
-# --- No implicit crawl ---
+# --- players_data is always required ---
 
 
-def test_no_implicit_crawl_when_players_not_provided():
-    """Creating MaccabiGamesStats without players_data should NOT crawl."""
+def test_players_data_required_for_player_stats():
+    """Without players_data, accessing player stats should fail."""
     games = [_make_game(datetime(2024, 9, 1))]
-    stats = MaccabiGamesStats(games)
-
-    # Non-player stats should work
-    assert len(stats) == 1
-    assert stats.results.wins_count == 1
-
-    # Player stats degrade to empty — no implicit network call
-    assert stats.players_data is None
-    assert stats.players_categories.maccabi_home_players_names == set()
+    with pytest.raises((AttributeError, TypeError)):
+        MaccabiGamesStats(games)

--- a/packages/maccabistats/tests/test_players_data_pickle.py
+++ b/packages/maccabistats/tests/test_players_data_pickle.py
@@ -130,8 +130,8 @@ def test_empty_games_does_not_crawl(monkeypatch):
 # --- Backward compatibility ---
 
 
-def test_old_pickle_without_players_data_falls_back_to_crawl(monkeypatch):
-    """Old pickles without maccabipedia_players should fall back to crawling."""
+def test_old_pickle_without_players_data_has_none():
+    """Old pickles without maccabipedia_players result in None — no implicit crawl."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
     stats = MaccabiGamesStats(games, maccabipedia_players=players)
@@ -141,29 +141,17 @@ def test_old_pickle_without_players_data_falls_back_to_crawl(monkeypatch):
     pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
 
-    # Verify the old pickle has no maccabipedia_players
     restored = pickle.loads(pickled)
     assert not hasattr(restored, 'maccabipedia_players')
 
-    # Monkeypatch _crawl_players_data to return known data (simulates a real crawl)
-    crawl_called = False
-
-    def fake_crawl():
-        nonlocal crawl_called
-        crawl_called = True
-        return _TEST_PLAYERS_DATA
-
-    monkeypatch.setattr(MaccabiPediaPlayers, '_crawl_players_data', staticmethod(fake_crawl))
-
-    # Simulate get_maccabi_stats_as_newest_wrapper path:
-    # getattr returns None → __init__ falls back to crawl
+    # Wrapping in new MaccabiGamesStats with getattr — gets None, stays None
     wrapper = MaccabiGamesStats(
         restored.games,
         maccabipedia_players=getattr(restored, 'maccabipedia_players', None),
     )
-    assert crawl_called, "Should have crawled from MaccabiPedia for old pickle"
-    assert wrapper.maccabipedia_players is not None
-    assert wrapper.maccabipedia_players.home_players == {"שחקן א"}
+    assert wrapper.maccabipedia_players is None
+    # Non-player stats still work
+    assert len(wrapper) == 1
 
 
 # --- players_special_games ---
@@ -201,17 +189,11 @@ def test_filter_chain_preserves_players_data(monkeypatch):
     assert chained.players_special_games.players_birth_dates["שחקן א"] == datetime(2000, 1, 1)
 
 
-# --- Graceful degradation ---
+# --- No implicit crawl ---
 
 
-def test_crawl_failure_degrades_gracefully(monkeypatch):
-    """If crawling fails, non-player stats should still work."""
-    monkeypatch.setattr(
-        MaccabiPediaPlayers, '_crawl_players_data',
-        staticmethod(lambda: (_ for _ in ()).throw(ConnectionError("No internet"))),
-    )
-    MaccabiPediaPlayers._instance = None
-
+def test_no_implicit_crawl_when_players_not_provided():
+    """Creating MaccabiGamesStats without maccabipedia_players should NOT crawl."""
     games = [_make_game(datetime(2024, 9, 1))]
     stats = MaccabiGamesStats(games)
 
@@ -219,6 +201,6 @@ def test_crawl_failure_degrades_gracefully(monkeypatch):
     assert len(stats) == 1
     assert stats.results.wins_count == 1
 
-    # Player stats should degrade to empty
-    assert stats.players_categories.maccabi_home_players_names == set()
+    # Player stats degrade to empty — no implicit network call
     assert stats.maccabipedia_players is None
+    assert stats.players_categories.maccabi_home_players_names == set()

--- a/packages/maccabistats/tests/test_players_data_pickle.py
+++ b/packages/maccabistats/tests/test_players_data_pickle.py
@@ -26,92 +26,100 @@ def _make_game(date: datetime) -> GameData:
     )
 
 
-def _setup_players_singleton():
-    """Set up MaccabiPediaPlayers singleton with test data."""
+def _make_players_instance():
+    """Create a MaccabiPediaPlayers instance with test data."""
     players_data = {
         "שחקן א": MaccabiPediaPlayerData(name="שחקן א", birth_date=datetime(2000, 1, 1), is_home_player=True),
         "שחקן ב": MaccabiPediaPlayerData(name="שחקן ב", birth_date=datetime(1995, 6, 15), is_home_player=False),
     }
     MaccabiPediaPlayers.load_from_cache(players_data)
-    return players_data
+    return MaccabiPediaPlayers.get_players_data()
 
 
-def test_pickle_includes_players_data():
-    """Players data should be included in the pickle state."""
-    _setup_players_singleton()
+def test_players_data_stored_as_attribute():
+    """Players data should be stored as a regular attribute on MaccabiGamesStats."""
+    players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
-    stats = MaccabiGamesStats(games)
+    stats = MaccabiGamesStats(games, _maccabipedia_players=players)
 
-    state = stats.__getstate__()
-    assert '_players_data_cache' in state
-    assert "שחקן א" in state['_players_data_cache']
-    assert "שחקן ב" in state['_players_data_cache']
+    assert stats._maccabipedia_players is players
+    assert stats.players_categories.maccabi_home_players_names == {"שחקן א"}
 
-    # Clean up singleton
     MaccabiPediaPlayers._instance = None
 
 
-def test_unpickle_restores_players_singleton():
-    """Unpickling should restore the MaccabiPediaPlayers singleton without internet."""
-    original_data = _setup_players_singleton()
+def test_pickle_roundtrip_preserves_players_data():
+    """Pickling and unpickling should preserve the players data without crawling."""
+    players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
-    stats = MaccabiGamesStats(games)
+    stats = MaccabiGamesStats(games, _maccabipedia_players=players)
 
     # Pickle and clear singleton
     pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
 
-    # Unpickle - should restore singleton from cache
+    # Unpickle — should restore players data from the attribute, not crawl
     restored = pickle.loads(pickled)
-    assert MaccabiPediaPlayers._instance is not None
-    assert MaccabiPediaPlayers.get_players_data().home_players == {"שחקן א"}
-    assert MaccabiPediaPlayers.get_players_data().players_dates["שחקן ב"] == datetime(1995, 6, 15)
+    assert restored._maccabipedia_players is not None
+    assert restored._maccabipedia_players.home_players == {"שחקן א"}
+    assert restored._maccabipedia_players.players_dates["שחקן ב"] == datetime(1995, 6, 15)
 
-    # Clean up
     MaccabiPediaPlayers._instance = None
 
 
-def test_unpickle_then_create_new_stats_works_offline(monkeypatch):
-    """After unpickling, creating new MaccabiGamesStats (e.g. filtering) should not crawl."""
-    _setup_players_singleton()
+def test_filtered_stats_inherit_players_data(monkeypatch):
+    """Filter properties (e.g. home_games) should inherit players data without crawling."""
+    players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1)), _make_game(datetime(2024, 10, 1))]
-    stats = MaccabiGamesStats(games)
+    stats = MaccabiGamesStats(games, _maccabipedia_players=players)
+
+    # Block any network crawling
+    monkeypatch.setattr(
+        MaccabiPediaPlayers, '_crawl_players_data',
+        staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("Should not crawl!"))),
+    )
+    MaccabiPediaPlayers._instance = None
+
+    # Filter properties create new MaccabiGamesStats — should use inherited players data
+    filtered = stats.maccabi_wins
+    assert filtered._maccabipedia_players is players
+    assert filtered.players_categories.maccabi_home_players_names == {"שחקן א"}
+
+    MaccabiPediaPlayers._instance = None
+
+
+def test_unpickle_then_filter_works_offline(monkeypatch):
+    """After unpickling, creating filtered stats should work without internet."""
+    players = _make_players_instance()
+    games = [_make_game(datetime(2024, 9, 1)), _make_game(datetime(2024, 10, 1))]
+    stats = MaccabiGamesStats(games, _maccabipedia_players=players)
 
     pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
 
-    # Block any network crawling - if it tries to crawl, the test fails
+    # Block any network crawling
     monkeypatch.setattr(
         MaccabiPediaPlayers, '_crawl_players_data',
         staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("Should not crawl!"))),
     )
 
     restored = pickle.loads(pickled)
-    # Creating a new MaccabiGamesStats from the restored games (like filter properties do)
-    # should use the already-populated singleton
-    filtered = MaccabiGamesStats(restored.games)
+    # Creating a new MaccabiGamesStats via filter should use restored players data
+    filtered = MaccabiGamesStats(restored.games, _maccabipedia_players=restored._maccabipedia_players)
     assert filtered.players_categories.maccabi_home_players_names == {"שחקן א"}
 
-    # Clean up
     MaccabiPediaPlayers._instance = None
 
 
-def test_backwards_compatible_with_old_pickles():
-    """Old pickle files without players data should still work (falling back to crawl)."""
-    _setup_players_singleton()
-    games = [_make_game(datetime(2024, 9, 1))]
-    stats = MaccabiGamesStats(games)
-
-    # Simulate an old pickle without _players_data_cache
-    state = stats.__getstate__()
-    del state['_players_data_cache']
-
+def test_empty_games_does_not_crawl(monkeypatch):
+    """Creating MaccabiGamesStats with empty games should not trigger crawling."""
+    monkeypatch.setattr(
+        MaccabiPediaPlayers, '_crawl_players_data',
+        staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("Should not crawl!"))),
+    )
     MaccabiPediaPlayers._instance = None
-    stats2 = object.__new__(MaccabiGamesStats)
-    stats2.__setstate__(state)
 
-    # Singleton should still be None (no cache to restore from)
-    assert MaccabiPediaPlayers._instance is None
+    stats = MaccabiGamesStats([])
+    assert stats._maccabipedia_players is None
 
-    # Clean up
     MaccabiPediaPlayers._instance = None

--- a/packages/maccabistats/tests/test_players_data_pickle.py
+++ b/packages/maccabistats/tests/test_players_data_pickle.py
@@ -1,0 +1,117 @@
+"""Test that MaccabiGamesStats includes players data in pickle for offline loading."""
+
+import pickle
+from datetime import datetime
+
+from maccabistats.maccabipedia.players import MaccabiPediaPlayers, MaccabiPediaPlayerData
+from maccabistats.models.game_data import GameData
+from maccabistats.models.player_in_game import PlayerInGame
+from maccabistats.models.team_in_game import TeamInGame
+from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
+
+
+def _make_game(date: datetime) -> GameData:
+    """Create a minimal GameData for testing."""
+    maccabi = TeamInGame(name="מכבי תל אביב", coach="מאמן", score=1, players=[
+        PlayerInGame(name="שחקן א", number=7, game_events=[]),
+    ])
+    opponent = TeamInGame(name="הפועל תל אביב", coach="מאמן2", score=0, players=[
+        PlayerInGame(name="יריב א", number=9, game_events=[]),
+    ])
+    return GameData(
+        competition="ליגת העל", fixture="1", date_as_hebrew_string="",
+        stadium="בלומפילד", crowd="1000", referee="שופט",
+        home_team=maccabi, away_team=opponent,
+        season_string="2024/25", half_parsed_events=[], date=date,
+    )
+
+
+def _setup_players_singleton():
+    """Set up MaccabiPediaPlayers singleton with test data."""
+    players_data = {
+        "שחקן א": MaccabiPediaPlayerData(name="שחקן א", birth_date=datetime(2000, 1, 1), is_home_player=True),
+        "שחקן ב": MaccabiPediaPlayerData(name="שחקן ב", birth_date=datetime(1995, 6, 15), is_home_player=False),
+    }
+    MaccabiPediaPlayers.load_from_cache(players_data)
+    return players_data
+
+
+def test_pickle_includes_players_data():
+    """Players data should be included in the pickle state."""
+    _setup_players_singleton()
+    games = [_make_game(datetime(2024, 9, 1))]
+    stats = MaccabiGamesStats(games)
+
+    state = stats.__getstate__()
+    assert '_players_data_cache' in state
+    assert "שחקן א" in state['_players_data_cache']
+    assert "שחקן ב" in state['_players_data_cache']
+
+    # Clean up singleton
+    MaccabiPediaPlayers._instance = None
+
+
+def test_unpickle_restores_players_singleton():
+    """Unpickling should restore the MaccabiPediaPlayers singleton without internet."""
+    original_data = _setup_players_singleton()
+    games = [_make_game(datetime(2024, 9, 1))]
+    stats = MaccabiGamesStats(games)
+
+    # Pickle and clear singleton
+    pickled = pickle.dumps(stats)
+    MaccabiPediaPlayers._instance = None
+
+    # Unpickle - should restore singleton from cache
+    restored = pickle.loads(pickled)
+    assert MaccabiPediaPlayers._instance is not None
+    assert MaccabiPediaPlayers.get_players_data().home_players == {"שחקן א"}
+    assert MaccabiPediaPlayers.get_players_data().players_dates["שחקן ב"] == datetime(1995, 6, 15)
+
+    # Clean up
+    MaccabiPediaPlayers._instance = None
+
+
+def test_unpickle_then_create_new_stats_works_offline(monkeypatch):
+    """After unpickling, creating new MaccabiGamesStats (e.g. filtering) should not crawl."""
+    _setup_players_singleton()
+    games = [_make_game(datetime(2024, 9, 1)), _make_game(datetime(2024, 10, 1))]
+    stats = MaccabiGamesStats(games)
+
+    pickled = pickle.dumps(stats)
+    MaccabiPediaPlayers._instance = None
+
+    # Block any network crawling - if it tries to crawl, the test fails
+    monkeypatch.setattr(
+        MaccabiPediaPlayers, '_crawl_players_data',
+        staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("Should not crawl!"))),
+    )
+
+    restored = pickle.loads(pickled)
+    # Creating a new MaccabiGamesStats from the restored games (like filter properties do)
+    # should use the already-populated singleton
+    filtered = MaccabiGamesStats(restored.games)
+    assert filtered.players_categories.maccabi_home_players_names == {"שחקן א"}
+
+    # Clean up
+    MaccabiPediaPlayers._instance = None
+
+
+def test_backwards_compatible_with_old_pickles():
+    """Old pickle files without players data should still work (falling back to crawl)."""
+    _setup_players_singleton()
+    games = [_make_game(datetime(2024, 9, 1))]
+    stats = MaccabiGamesStats(games)
+
+    # Simulate an old pickle without _players_data_cache
+    state = stats.__getstate__()
+    del state['_players_data_cache']
+
+    MaccabiPediaPlayers._instance = None
+    stats2 = object.__new__(MaccabiGamesStats)
+    stats2.__setstate__(state)
+
+    # Singleton should still be None (no cache to restore from)
+    assert MaccabiPediaPlayers._instance is None
+
+    # Clean up
+    MaccabiPediaPlayers._instance = None

--- a/packages/maccabistats/tests/test_players_data_pickle.py
+++ b/packages/maccabistats/tests/test_players_data_pickle.py
@@ -3,11 +3,19 @@
 import pickle
 from datetime import datetime
 
+import pytest
+
 from maccabistats.maccabipedia.players import MaccabiPediaPlayers, MaccabiPediaPlayerData
 from maccabistats.models.game_data import GameData
 from maccabistats.models.player_in_game import PlayerInGame
 from maccabistats.models.team_in_game import TeamInGame
 from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
+
+
+@pytest.fixture(autouse=True)
+def reset_players_singleton():
+    yield
+    MaccabiPediaPlayers._instance = None
 
 
 def _make_game(date: datetime) -> GameData:
@@ -32,83 +40,68 @@ def _make_players_instance():
         "שחקן א": MaccabiPediaPlayerData(name="שחקן א", birth_date=datetime(2000, 1, 1), is_home_player=True),
         "שחקן ב": MaccabiPediaPlayerData(name="שחקן ב", birth_date=datetime(1995, 6, 15), is_home_player=False),
     }
-    MaccabiPediaPlayers.load_from_cache(players_data)
-    return MaccabiPediaPlayers.get_players_data()
+    return MaccabiPediaPlayers.load_from_cache(players_data)
 
 
 def test_players_data_stored_as_attribute():
     """Players data should be stored as a regular attribute on MaccabiGamesStats."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
-    stats = MaccabiGamesStats(games, _maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, maccabipedia_players=players)
 
-    assert stats._maccabipedia_players is players
+    assert stats.maccabipedia_players is players
     assert stats.players_categories.maccabi_home_players_names == {"שחקן א"}
-
-    MaccabiPediaPlayers._instance = None
 
 
 def test_pickle_roundtrip_preserves_players_data():
     """Pickling and unpickling should preserve the players data without crawling."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
-    stats = MaccabiGamesStats(games, _maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, maccabipedia_players=players)
 
-    # Pickle and clear singleton
     pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
 
-    # Unpickle — should restore players data from the attribute, not crawl
     restored = pickle.loads(pickled)
-    assert restored._maccabipedia_players is not None
-    assert restored._maccabipedia_players.home_players == {"שחקן א"}
-    assert restored._maccabipedia_players.players_dates["שחקן ב"] == datetime(1995, 6, 15)
-
-    MaccabiPediaPlayers._instance = None
+    assert restored.maccabipedia_players is not None
+    assert restored.maccabipedia_players.home_players == {"שחקן א"}
+    assert restored.maccabipedia_players.players_dates["שחקן ב"] == datetime(1995, 6, 15)
 
 
 def test_filtered_stats_inherit_players_data(monkeypatch):
     """Filter properties (e.g. home_games) should inherit players data without crawling."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1)), _make_game(datetime(2024, 10, 1))]
-    stats = MaccabiGamesStats(games, _maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, maccabipedia_players=players)
 
-    # Block any network crawling
     monkeypatch.setattr(
         MaccabiPediaPlayers, '_crawl_players_data',
         staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("Should not crawl!"))),
     )
     MaccabiPediaPlayers._instance = None
 
-    # Filter properties create new MaccabiGamesStats — should use inherited players data
     filtered = stats.maccabi_wins
-    assert filtered._maccabipedia_players is players
+    assert filtered.maccabipedia_players is players
     assert filtered.players_categories.maccabi_home_players_names == {"שחקן א"}
-
-    MaccabiPediaPlayers._instance = None
 
 
 def test_unpickle_then_filter_works_offline(monkeypatch):
     """After unpickling, creating filtered stats should work without internet."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1)), _make_game(datetime(2024, 10, 1))]
-    stats = MaccabiGamesStats(games, _maccabipedia_players=players)
+    stats = MaccabiGamesStats(games, maccabipedia_players=players)
 
     pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
 
-    # Block any network crawling
     monkeypatch.setattr(
         MaccabiPediaPlayers, '_crawl_players_data',
         staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("Should not crawl!"))),
     )
 
     restored = pickle.loads(pickled)
-    # Creating a new MaccabiGamesStats via filter should use restored players data
-    filtered = MaccabiGamesStats(restored.games, _maccabipedia_players=restored._maccabipedia_players)
+    filtered = MaccabiGamesStats(restored.games, maccabipedia_players=restored.maccabipedia_players)
     assert filtered.players_categories.maccabi_home_players_names == {"שחקן א"}
-
-    MaccabiPediaPlayers._instance = None
 
 
 def test_empty_games_does_not_crawl(monkeypatch):
@@ -120,6 +113,44 @@ def test_empty_games_does_not_crawl(monkeypatch):
     MaccabiPediaPlayers._instance = None
 
     stats = MaccabiGamesStats([])
-    assert stats._maccabipedia_players is None
+    assert stats.maccabipedia_players is None
 
+
+def test_old_pickle_without_players_data_falls_back_to_crawl():
+    """Old pickles without maccabipedia_players should fall back to crawling (backward compat)."""
+    players = _make_players_instance()
+    games = [_make_game(datetime(2024, 9, 1))]
+    stats = MaccabiGamesStats(games, maccabipedia_players=players)
+
+    # Simulate an old pickle by removing the attribute before pickling
+    del stats.__dict__['maccabipedia_players']
+    pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
+
+    # Loading through get_maccabi_stats_as_newest_wrapper-style path:
+    # getattr(loaded, 'maccabipedia_players', None) returns None → __init__ falls back to crawl
+    restored = pickle.loads(pickled)
+    assert not hasattr(restored, 'maccabipedia_players')
+
+    # When wrapping in a new MaccabiGamesStats, the fallback triggers crawl
+    # (here we set up the singleton so it "crawls" from cache)
+    MaccabiPediaPlayers.load_from_cache({
+        "שחקן א": MaccabiPediaPlayerData(name="שחקן א", birth_date=datetime(2000, 1, 1), is_home_player=True),
+    })
+    wrapper = MaccabiGamesStats(
+        restored.games,
+        maccabipedia_players=getattr(restored, 'maccabipedia_players', None),
+    )
+    # Since getattr returns None and there are games, it falls back to singleton crawl
+    assert wrapper.maccabipedia_players is not None
+
+
+def test_load_from_cache_returns_instance():
+    """load_from_cache should return the created instance."""
+    players_data = {
+        "שחקן א": MaccabiPediaPlayerData(name="שחקן א", birth_date=datetime(2000, 1, 1), is_home_player=True),
+    }
+    instance = MaccabiPediaPlayers.load_from_cache(players_data)
+    assert instance is not None
+    assert instance is MaccabiPediaPlayers._instance
+    assert instance.home_players == {"שחקן א"}

--- a/packages/maccabistats/tests/test_players_data_pickle.py
+++ b/packages/maccabistats/tests/test_players_data_pickle.py
@@ -126,8 +126,8 @@ def test_empty_games_works_with_players_data():
 # --- Backward compatibility ---
 
 
-def test_old_pickle_without_players_data_fails_loudly():
-    """Old pickles without players_data should fail with AttributeError."""
+def test_old_pickle_without_players_data_fails_with_clear_error():
+    """Old pickles without players_data should fail with a clear RuntimeError."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
     stats = MaccabiGamesStats(games, players_data=players)
@@ -137,9 +137,8 @@ def test_old_pickle_without_players_data_fails_loudly():
     pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
 
-    restored = pickle.loads(pickled)
-    with pytest.raises(AttributeError):
-        _ = restored.players_data
+    with pytest.raises(RuntimeError, match="does not contain players_data"):
+        pickle.loads(pickled)
 
 
 # --- players_special_games ---

--- a/packages/maccabistats/tests/test_players_data_pickle.py
+++ b/packages/maccabistats/tests/test_players_data_pickle.py
@@ -11,6 +11,11 @@ from maccabistats.models.player_in_game import PlayerInGame
 from maccabistats.models.team_in_game import TeamInGame
 from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
 
+_TEST_PLAYERS_DATA = {
+    "שחקן א": MaccabiPediaPlayerData(name="שחקן א", birth_date=datetime(2000, 1, 1), is_home_player=True),
+    "שחקן ב": MaccabiPediaPlayerData(name="שחקן ב", birth_date=datetime(1995, 6, 15), is_home_player=False),
+}
+
 
 @pytest.fixture(autouse=True)
 def reset_players_singleton():
@@ -36,11 +41,10 @@ def _make_game(date: datetime) -> GameData:
 
 def _make_players_instance():
     """Create a MaccabiPediaPlayers instance with test data."""
-    players_data = {
-        "שחקן א": MaccabiPediaPlayerData(name="שחקן א", birth_date=datetime(2000, 1, 1), is_home_player=True),
-        "שחקן ב": MaccabiPediaPlayerData(name="שחקן ב", birth_date=datetime(1995, 6, 15), is_home_player=False),
-    }
-    return MaccabiPediaPlayers.load_from_cache(players_data)
+    return MaccabiPediaPlayers.load_from_cache(_TEST_PLAYERS_DATA)
+
+
+# --- Core feature tests ---
 
 
 def test_players_data_stored_as_attribute():
@@ -116,8 +120,11 @@ def test_empty_games_does_not_crawl(monkeypatch):
     assert stats.maccabipedia_players is None
 
 
-def test_old_pickle_without_players_data_falls_back_to_crawl():
-    """Old pickles without maccabipedia_players should fall back to crawling (backward compat)."""
+# --- Backward compatibility ---
+
+
+def test_old_pickle_without_players_data_falls_back_to_crawl(monkeypatch):
+    """Old pickles without maccabipedia_players should fall back to crawling."""
     players = _make_players_instance()
     games = [_make_game(datetime(2024, 9, 1))]
     stats = MaccabiGamesStats(games, maccabipedia_players=players)
@@ -127,30 +134,95 @@ def test_old_pickle_without_players_data_falls_back_to_crawl():
     pickled = pickle.dumps(stats)
     MaccabiPediaPlayers._instance = None
 
-    # Loading through get_maccabi_stats_as_newest_wrapper-style path:
-    # getattr(loaded, 'maccabipedia_players', None) returns None → __init__ falls back to crawl
+    # Verify the old pickle has no maccabipedia_players
     restored = pickle.loads(pickled)
     assert not hasattr(restored, 'maccabipedia_players')
 
-    # When wrapping in a new MaccabiGamesStats, the fallback triggers crawl
-    # (here we set up the singleton so it "crawls" from cache)
-    MaccabiPediaPlayers.load_from_cache({
-        "שחקן א": MaccabiPediaPlayerData(name="שחקן א", birth_date=datetime(2000, 1, 1), is_home_player=True),
-    })
+    # Monkeypatch _crawl_players_data to return known data (simulates a real crawl)
+    crawl_called = False
+
+    def fake_crawl():
+        nonlocal crawl_called
+        crawl_called = True
+        return _TEST_PLAYERS_DATA
+
+    monkeypatch.setattr(MaccabiPediaPlayers, '_crawl_players_data', staticmethod(fake_crawl))
+
+    # Simulate get_maccabi_stats_as_newest_wrapper path:
+    # getattr returns None → __init__ falls back to crawl
     wrapper = MaccabiGamesStats(
         restored.games,
         maccabipedia_players=getattr(restored, 'maccabipedia_players', None),
     )
-    # Since getattr returns None and there are games, it falls back to singleton crawl
+    assert crawl_called, "Should have crawled from MaccabiPedia for old pickle"
     assert wrapper.maccabipedia_players is not None
+    assert wrapper.maccabipedia_players.home_players == {"שחקן א"}
+
+
+# --- players_special_games ---
+
+
+def test_players_special_games_uses_attribute():
+    """players_special_games should get birth dates from the maccabipedia_players attribute."""
+    players = _make_players_instance()
+    games = [_make_game(datetime(2024, 9, 1))]
+    stats = MaccabiGamesStats(games, maccabipedia_players=players)
+
+    assert stats.players_special_games.players_birth_dates["שחקן א"] == datetime(2000, 1, 1)
+    assert stats.players_special_games.players_birth_dates["שחקן ב"] == datetime(1995, 6, 15)
+
+
+# --- Filter chain ---
+
+
+def test_filter_chain_preserves_players_data(monkeypatch):
+    """Multi-level filter chains should preserve players data throughout."""
+    players = _make_players_instance()
+    games = [_make_game(datetime(2024, 9, 1)), _make_game(datetime(2024, 10, 1))]
+    stats = MaccabiGamesStats(games, maccabipedia_players=players)
+
+    monkeypatch.setattr(
+        MaccabiPediaPlayers, '_crawl_players_data',
+        staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("Should not crawl!"))),
+    )
+    MaccabiPediaPlayers._instance = None
+
+    # Chain: home_games → maccabi_wins → players_categories
+    chained = stats.home_games.maccabi_wins
+    assert chained.maccabipedia_players is players
+    assert chained.players_categories.maccabi_home_players_names == {"שחקן א"}
+    assert chained.players_special_games.players_birth_dates["שחקן א"] == datetime(2000, 1, 1)
+
+
+# --- Graceful degradation ---
+
+
+def test_crawl_failure_degrades_gracefully(monkeypatch):
+    """If crawling fails, non-player stats should still work."""
+    monkeypatch.setattr(
+        MaccabiPediaPlayers, '_crawl_players_data',
+        staticmethod(lambda: (_ for _ in ()).throw(ConnectionError("No internet"))),
+    )
+    MaccabiPediaPlayers._instance = None
+
+    games = [_make_game(datetime(2024, 9, 1))]
+    stats = MaccabiGamesStats(games)
+
+    # Non-player stats should work
+    assert len(stats) == 1
+    assert stats.results.wins_count == 1
+
+    # Player stats should degrade to empty
+    assert stats.players_categories.maccabi_home_players_names == set()
+    assert stats.maccabipedia_players is None
+
+
+# --- load_from_cache ---
 
 
 def test_load_from_cache_returns_instance():
     """load_from_cache should return the created instance."""
-    players_data = {
-        "שחקן א": MaccabiPediaPlayerData(name="שחקן א", birth_date=datetime(2000, 1, 1), is_home_player=True),
-    }
-    instance = MaccabiPediaPlayers.load_from_cache(players_data)
+    instance = MaccabiPediaPlayers.load_from_cache(_TEST_PLAYERS_DATA)
     assert instance is not None
     assert instance is MaccabiPediaPlayers._instance
     assert instance.home_players == {"שחקן א"}


### PR DESCRIPTION
## Summary
- `MaccabiGamesStats` now stores `players_data` as a regular attribute that pickles naturally — no internet needed on load
- Sub-stats (`players_categories`, `players_special_games`) get players data from the parent instead of crawling via global singleton
- All filter methods use `create_maccabi_games_stats_with_filtered_games()` to propagate `players_data` to child instances
- Callers that need players data pass it explicitly — no hidden network calls in `__init__`
- Old pickles (< 2.60) fail with a clear error message and instructions to re-crawl
- Version bumped to 2.60

**After merge:** run `run_maccabipedia_source()` once to create a new pickle with embedded players data. After that, all loads work offline.

Closes: https://trello.com/c/5EFk6nKA

## Test plan
- [x] 9 unit tests covering pickle roundtrip, filter chain, offline loading, old pickle error, etc.
- [ ] Run `run_maccabipedia_source()` to produce a new pickle with players_data
- [ ] Load the new pickle offline and verify no network requests are made

🤖 Generated with [Claude Code](https://claude.com/claude-code)