### PR TITLE
refactor: replace hardcoded paths in maccabistats

### DIFF
--- a/packages/maccabistats/CHANGELOG.md
+++ b/packages/maccabistats/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 2.61 ##
+
+    Replace hardcoded Windows paths with configurable MACCABISTATS_DATA_DIR env var (defaults to ~/maccabistats/)
+
 ## Version 2.53 ##
 
     Add 3 new ErrorsFinder checks: sub-out without playing, same player on both teams, duplicate events

--- a/packages/maccabistats/src/maccabistats/config/config.py
+++ b/packages/maccabistats/src/maccabistats/config/config.py
@@ -3,6 +3,9 @@ from dataclasses import dataclass
 from .maccabipedia_config import MaccabiPediaConfig
 from .maccabisite_config import MaccabiSiteConfig
 
+# Re-export for convenience
+from .maccabisite_config import MACCABISTATS_DATA_DIR  # noqa: F401
+
 
 @dataclass
 class MaccabiStatsConfig:

--- a/packages/maccabistats/src/maccabistats/config/config.py
+++ b/packages/maccabistats/src/maccabistats/config/config.py
@@ -3,9 +3,6 @@ from dataclasses import dataclass
 from .maccabipedia_config import MaccabiPediaConfig
 from .maccabisite_config import MaccabiSiteConfig
 
-# Re-export for convenience
-from .maccabisite_config import get_maccabistats_data_dir  # noqa: F401
-
 
 @dataclass
 class MaccabiStatsConfig:

--- a/packages/maccabistats/src/maccabistats/config/config.py
+++ b/packages/maccabistats/src/maccabistats/config/config.py
@@ -4,7 +4,7 @@ from .maccabipedia_config import MaccabiPediaConfig
 from .maccabisite_config import MaccabiSiteConfig
 
 # Re-export for convenience
-from .maccabisite_config import MACCABISTATS_DATA_DIR  # noqa: F401
+from .maccabisite_config import get_maccabistats_data_dir  # noqa: F401
 
 
 @dataclass

--- a/packages/maccabistats/src/maccabistats/config/maccabisite_config.py
+++ b/packages/maccabistats/src/maccabistats/config/maccabisite_config.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 
 def get_maccabistats_data_dir() -> Path:
-    return Path(os.environ.get("MACCABISTATS_DATA_DIR", Path.home() / "maccabistats"))
+    env_val = os.environ.get("MACCABISTATS_DATA_DIR")
+    return Path(env_val) if env_val else Path.home() / "maccabistats"
 
 
 @dataclass

--- a/packages/maccabistats/src/maccabistats/config/maccabisite_config.py
+++ b/packages/maccabistats/src/maccabistats/config/maccabisite_config.py
@@ -1,12 +1,16 @@
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+MACCABISTATS_DATA_DIR = Path(os.environ.get("MACCABISTATS_DATA_DIR", Path.home() / "maccabistats"))
 
 
 @dataclass
 class MaccabiSiteConfig:
     max_seasons_to_crawl: int = 87
     season_page_pattern: str = 'https://www.maccabi-tlv.co.il/משחקים-ותוצאות/הקבוצה-הבוגרת/תוצאות/?season={season_number}#content'
-    folder_to_save_seasons_html_files = 'c:\maccabi\seasons'
-    folder_to_save_games_html_files = 'c:\maccabi\games'
+    folder_to_save_seasons_html_files: str = field(default_factory=lambda: str(MACCABISTATS_DATA_DIR / "crawl" / "seasons"))
+    folder_to_save_games_html_files: str = field(default_factory=lambda: str(MACCABISTATS_DATA_DIR / "crawl" / "games"))
     use_disk_as_cache_when_crawling = True
     use_lxml_parser = True
     use_multiprocess_crawling = True

--- a/packages/maccabistats/src/maccabistats/config/maccabisite_config.py
+++ b/packages/maccabistats/src/maccabistats/config/maccabisite_config.py
@@ -1,11 +1,17 @@
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 
 def get_maccabistats_data_dir() -> Path:
     env_val = os.environ.get("MACCABISTATS_DATA_DIR")
-    return Path(env_val) if env_val else Path.home() / "maccabistats"
+    if env_val:
+        logger.info(f"Using custom data directory from MACCABISTATS_DATA_DIR: {env_val}")
+        return Path(env_val)
+    return Path.home() / "maccabistats"
 
 
 @dataclass

--- a/packages/maccabistats/src/maccabistats/config/maccabisite_config.py
+++ b/packages/maccabistats/src/maccabistats/config/maccabisite_config.py
@@ -2,15 +2,17 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
-MACCABISTATS_DATA_DIR = Path(os.environ.get("MACCABISTATS_DATA_DIR", Path.home() / "maccabistats"))
+
+def get_maccabistats_data_dir() -> Path:
+    return Path(os.environ.get("MACCABISTATS_DATA_DIR", Path.home() / "maccabistats"))
 
 
 @dataclass
 class MaccabiSiteConfig:
     max_seasons_to_crawl: int = 87
     season_page_pattern: str = 'https://www.maccabi-tlv.co.il/משחקים-ותוצאות/הקבוצה-הבוגרת/תוצאות/?season={season_number}#content'
-    folder_to_save_seasons_html_files: str = field(default_factory=lambda: str(MACCABISTATS_DATA_DIR / "crawl" / "seasons"))
-    folder_to_save_games_html_files: str = field(default_factory=lambda: str(MACCABISTATS_DATA_DIR / "crawl" / "games"))
+    folder_to_save_seasons_html_files: str = field(default_factory=lambda: str(get_maccabistats_data_dir() / "crawl" / "seasons"))
+    folder_to_save_games_html_files: str = field(default_factory=lambda: str(get_maccabistats_data_dir() / "crawl" / "games"))
     use_disk_as_cache_when_crawling = True
     use_lxml_parser = True
     use_multiprocess_crawling = True

--- a/packages/maccabistats/src/maccabistats/config/maccabisite_config.py
+++ b/packages/maccabistats/src/maccabistats/config/maccabisite_config.py
@@ -8,10 +8,11 @@ logger = logging.getLogger(__name__)
 
 def get_maccabistats_data_dir() -> Path:
     env_val = os.environ.get("MACCABISTATS_DATA_DIR")
-    if env_val:
-        logger.info(f"Using custom data directory from MACCABISTATS_DATA_DIR: {env_val}")
-        return Path(env_val)
-    return Path.home() / "maccabistats"
+    if not env_val:
+        return Path.home() / "maccabistats"
+
+    logger.info(f"Using custom data directory from MACCABISTATS_DATA_DIR: {env_val}")
+    return Path(env_val)
 
 
 @dataclass

--- a/packages/maccabistats/src/maccabistats/scripts/top_players_by_achievements.py
+++ b/packages/maccabistats/src/maccabistats/scripts/top_players_by_achievements.py
@@ -7,11 +7,12 @@ from progressbar import ProgressBar
 from typing import Dict, Set
 
 from maccabistats import load_from_maccabipedia_source
+from maccabistats.config.maccabisite_config import MACCABISTATS_DATA_DIR
 from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
 
 _DESCRIPTION_WHICH_MEANS_MACCABI_WON_TITLE = ['מקום 1', 'זכיה']
 
-BASE_FOLDER = Path(r"C:\maccabipedia\infographics\titles")
+BASE_FOLDER = MACCABISTATS_DATA_DIR / "infographics" / "titles"
 
 
 # To check titles with coaches - uncomment line 42

--- a/packages/maccabistats/src/maccabistats/scripts/top_players_by_achievements.py
+++ b/packages/maccabistats/src/maccabistats/scripts/top_players_by_achievements.py
@@ -7,12 +7,10 @@ from progressbar import ProgressBar
 from typing import Dict, Set
 
 from maccabistats import load_from_maccabipedia_source
-from maccabistats.config.maccabisite_config import MACCABISTATS_DATA_DIR
+from maccabistats.config.maccabisite_config import get_maccabistats_data_dir
 from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
 
 _DESCRIPTION_WHICH_MEANS_MACCABI_WON_TITLE = ['מקום 1', 'זכיה']
-
-BASE_FOLDER = MACCABISTATS_DATA_DIR / "infographics" / "titles"
 
 
 # To check titles with coaches - uncomment line 42
@@ -72,8 +70,9 @@ if __name__ == '__main__':
 
     top_players = find_top_players_by_achievements(games, all_titles)
 
-    # (BASE_FOLDER / "top_players_achievements.json").write_text(json.dumps(top_players))
-    (BASE_FOLDER / "top_players_and_coaches_achievements.json").write_text(json.dumps(top_players))
+    output_folder = get_maccabistats_data_dir() / "infographics" / "titles"
+    # (output_folder / "top_players_achievements.json").write_text(json.dumps(top_players))
+    (output_folder / "top_players_and_coaches_achievements.json").write_text(json.dumps(top_players))
 
     print(f'\n\nPlayers sorted by titles amount: {pformat(top_players.most_common(50))}')
     a = 6

--- a/packages/maccabistats/src/maccabistats/scripts/top_players_by_achievements.py
+++ b/packages/maccabistats/src/maccabistats/scripts/top_players_by_achievements.py
@@ -71,8 +71,9 @@ if __name__ == '__main__':
     top_players = find_top_players_by_achievements(games, all_titles)
 
     output_folder = get_maccabistats_data_dir() / "infographics" / "titles"
-    # (output_folder / "top_players_achievements.json").write_text(json.dumps(top_players))
-    (output_folder / "top_players_and_coaches_achievements.json").write_text(json.dumps(top_players))
+    output_folder.mkdir(parents=True, exist_ok=True)
+    # (output_folder / "top_players_achievements.json").write_text(json.dumps(top_players, ensure_ascii=False), encoding='utf-8-sig')
+    (output_folder / "top_players_and_coaches_achievements.json").write_text(json.dumps(top_players, ensure_ascii=False), encoding='utf-8-sig')
 
     print(f'\n\nPlayers sorted by titles amount: {pformat(top_players.most_common(50))}')
     a = 6

--- a/packages/maccabistats/src/maccabistats/version.py
+++ b/packages/maccabistats/src/maccabistats/version.py
@@ -1,1 +1,1 @@
-version = "2.60"
+version = "2.61"


### PR DESCRIPTION
## Summary
- Replace hardcoded Windows paths (`C:\maccabi\...`, `C:\maccabipedia\...`) with a configurable base directory
- New `MACCABISTATS_DATA_DIR` env var defaults to `~/maccabistats/`, overridable per environment
- Crawl cache paths now resolve to `~/maccabistats/crawl/{seasons,games}`
- Script output path resolves to `~/maccabistats/infographics/titles`

## Test plan
- [x] All 224 maccabistats tests pass
- [ ] Verify crawl cache works with new default paths
- [ ] Verify `MACCABISTATS_DATA_DIR` override works when set

Trello: https://trello.com/c/PqpPYUxT/513

🤖 Generated with [Claude Code](https://claude.com/claude-code)