### PR TITLE
docs: add missing maccabistats changelog entries (v2.51, v2.60)

### DIFF
--- a/packages/maccabistats/CHANGELOG.md
+++ b/packages/maccabistats/CHANGELOG.md
@@ -2,6 +2,11 @@
 
     Replace hardcoded Windows paths with configurable MACCABISTATS_DATA_DIR env var (defaults to ~/maccabistats/)
 
+## Version 2.60 ##
+
+    Include players data in MaccabiGamesStats pickle for offline loading
+    MaccabiPediaPlayers singleton is now cached in the pickle, so loading works without internet access
+
 ## Version 2.53 ##
 
     Add 3 new ErrorsFinder checks: sub-out without playing, same player on both teams, duplicate events
@@ -9,6 +14,10 @@
 ## Version 2.52 ##
 
     Ignore EventType=13 (display-only events) from MaccabiPedia parser
+
+## Version 2.51 ##
+
+    Support crawling season 2025/26, use higher timeout
 
 ## Version 2.50 ##
 


### PR DESCRIPTION
## Summary

- Add **v2.51** entry: Support crawling season 2025/26 with higher timeout (was in the standalone maccabistats repo but never documented in CHANGELOG)
- Add **v2.60** entry: Include players data in MaccabiGamesStats pickle for offline loading (monorepo PR #70)

Note: versions 2.54–2.59 were skipped — they do not appear in either the standalone repo or monorepo history.

## Test plan

- [ ] Verify CHANGELOG ordering is correct (2.61 → 2.60 → 2.53 → 2.52 → 2.51 → 2.50 → ...)
- [ ] No functional changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)