### PR TITLE
feat(maccabistats): add best_scorers_in_one_game and best_assisters_in_one_game

### DIFF
--- a/packages/maccabistats/CHANGELOG.md
+++ b/packages/maccabistats/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Version 2.62 ##
+
+    Replace hardcoded Windows paths with configurable MACCABISTATS_DATA_DIR env var (defaults to ~/maccabistats/)
+
+## Version 2.60 ##
+
+    Include players data in MaccabiGamesStats pickle for offline loading
+    MaccabiPediaPlayers singleton is now cached in the pickle, so loading works without internet access
+
 ## Version 2.61 ##
 
     Replace hardcoded Windows paths with configurable MACCABISTATS_DATA_DIR env var (defaults to ~/maccabistats/)

--- a/packages/maccabistats/CHANGELOG.md
+++ b/packages/maccabistats/CHANGELOG.md
@@ -1,11 +1,7 @@
 ## Version 2.62 ##
 
-    Replace hardcoded Windows paths with configurable MACCABISTATS_DATA_DIR env var (defaults to ~/maccabistats/)
-
-## Version 2.60 ##
-
-    Include players data in MaccabiGamesStats pickle for offline loading
-    MaccabiPediaPlayers singleton is now cached in the pickle, so loading works without internet access
+    Add best_scorers_in_one_game(score_at_least) and best_assisters_in_one_game(assist_at_least)
+    to rank players by how many games they scored/assisted at least N goals (e.g. hattrick kings)
 
 ## Version 2.61 ##
 

--- a/packages/maccabistats/src/maccabistats/stats/players.py
+++ b/packages/maccabistats/src/maccabistats/stats/players.py
@@ -138,6 +138,15 @@ class MaccabiGamesPlayersStats(object):
             lambda p: p.event_count_by_type(GameEventTypes.GOAL_ASSIST) + p.event_count_by_type(
                 GameEventTypes.GOAL_SCORE) - p.goals_count_by_goal_type(GoalTypes.OWN_GOAL))
 
+    def best_scorers_in_one_game(self, score_at_least: int) -> List[PlayerStats]:
+        return self.__get_players_from_all_games_with_most_of_this_condition(
+            lambda p: 1 if p.event_count_by_type(GameEventTypes.GOAL_SCORE) - p.goals_count_by_goal_type(
+                GoalTypes.OWN_GOAL) >= score_at_least else 0)
+
+    def best_assisters_in_one_game(self, assist_at_least: int) -> List[PlayerStats]:
+        return self.__get_players_from_all_games_with_most_of_this_condition(
+            lambda p: 1 if p.event_count_by_type(GameEventTypes.GOAL_ASSIST) >= assist_at_least else 0)
+
     # endregion
 
     # region Top players by other game events sorting

--- a/packages/maccabistats/src/maccabistats/version.py
+++ b/packages/maccabistats/src/maccabistats/version.py
@@ -1,1 +1,1 @@
-version = "2.61"
+version = "2.62"

--- a/packages/maccabistats/tests/conftest.py
+++ b/packages/maccabistats/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
 
-from game_fixtures import GAMES
+from game_fixtures import GAMES, OWN_GOAL_GAME
 from players_data_fixtures import create_stub_players_data
 
 
@@ -10,3 +10,9 @@ from players_data_fixtures import create_stub_players_data
 def maccabi_games() -> MaccabiGamesStats:
     """A deterministic set of 10 synthetic games for offline testing."""
     return MaccabiGamesStats(GAMES, players_data=create_stub_players_data())
+
+
+@pytest.fixture(scope="session")
+def own_goal_games() -> MaccabiGamesStats:
+    """A single game where a Maccabi player scores only an own goal."""
+    return MaccabiGamesStats([OWN_GOAL_GAME], players_data=create_stub_players_data())

--- a/packages/maccabistats/tests/game_fixtures.py
+++ b/packages/maccabistats/tests/game_fixtures.py
@@ -353,7 +353,6 @@ GAMES.append(_game(
 ))
 
 # ---- Game 9: League, home, TIE 0-0 (clean sheet), season 2020/21 ----
-# בני טבק scores an own goal (used to test own-goal exclusion in best_scorers_in_one_game)
 GAMES.append(_game(
     competition="ליגת העל", fixture="מחזור3", season="2020/21",
     date=datetime.datetime(2020, 10, 10),
@@ -365,7 +364,7 @@ GAMES.append(_game(
         _player("טל בן חיים", 3, [_lineup()]),
         _player("אלכסנדר אובארוב", 1, [_lineup(), _penalty_stopped(70)]),
         _player("שייע גלזר", 5, [_lineup()]),
-        _player("בני טבק", 6, [_lineup(), _goal(55, GoalTypes.OWN_GOAL)]),
+        _player("בני טבק", 6, [_lineup()]),
         _player("גיורא שפיגל", 11, [_lineup()]),
         _player("יוסף מרימוביץ'", 4, [_lineup()]),
         _player("ויקי פרץ", 9, [_lineup()]),

--- a/packages/maccabistats/tests/game_fixtures.py
+++ b/packages/maccabistats/tests/game_fixtures.py
@@ -145,6 +145,17 @@ def _game(
 
 GAMES: list[GameData] = []
 
+# A single game where a Maccabi player scores only an own goal — used to test own-goal exclusion.
+OWN_GOAL_GAME = _game(
+    competition="ליגת העל", fixture="מחזור1", season="2020/21",
+    date=datetime.datetime(2020, 1, 1),
+    stadium="בלומפילד", referee="ref",
+    home_team=TeamInGame("מכבי תל אביב", "מאמן", 0, [
+        _player("שייע גלזר", 5, [_lineup(), _goal(30, GoalTypes.OWN_GOAL)]),
+    ]),
+    away_team=TeamInGame("יריב", "מאמן", 1, [_player("שוער", 1, [_lineup()])]),
+)
+
 # ---- Game 1: League, home, WIN 3-1, season 2019/20 ----
 # Maccabi: אבי נמני scores 2 (normal), אלי דריקס scores 1 (header)
 # חיים רביבו assists twice (normal + corner), אבי נמני is captain

--- a/packages/maccabistats/tests/game_fixtures.py
+++ b/packages/maccabistats/tests/game_fixtures.py
@@ -353,6 +353,7 @@ GAMES.append(_game(
 ))
 
 # ---- Game 9: League, home, TIE 0-0 (clean sheet), season 2020/21 ----
+# בני טבק scores an own goal (used to test own-goal exclusion in best_scorers_in_one_game)
 GAMES.append(_game(
     competition="ליגת העל", fixture="מחזור3", season="2020/21",
     date=datetime.datetime(2020, 10, 10),
@@ -364,7 +365,7 @@ GAMES.append(_game(
         _player("טל בן חיים", 3, [_lineup()]),
         _player("אלכסנדר אובארוב", 1, [_lineup(), _penalty_stopped(70)]),
         _player("שייע גלזר", 5, [_lineup()]),
-        _player("בני טבק", 6, [_lineup()]),
+        _player("בני טבק", 6, [_lineup(), _goal(55, GoalTypes.OWN_GOAL)]),
         _player("גיורא שפיגל", 11, [_lineup()]),
         _player("יוסף מרימוביץ'", 4, [_lineup()]),
         _player("ויקי פרץ", 9, [_lineup()]),

--- a/packages/maccabistats/tests/test_players.py
+++ b/packages/maccabistats/tests/test_players.py
@@ -137,6 +137,35 @@ class TestPenaltyMissed:
         assert missed.get("אבי נמני", 0) == 2
 
 
+class TestBestScorersInOneGame:
+    def test_best_scorers_in_one_game_with_two_goals(self, maccabi_games):
+        # score_at_least=2: אבי נמני scored 2 in game 1 (min 15, 70) and game 5 (min 50, 70)
+        result = dict(maccabi_games.players.best_scorers_in_one_game(score_at_least=2))
+        assert result["אבי נמני"] == 2
+
+    def test_best_scorers_in_one_game_excludes_below_threshold(self, maccabi_games):
+        # score_at_least=2: אלי דריקס scored 1 per game max, should not appear
+        result = dict(maccabi_games.players.best_scorers_in_one_game(score_at_least=2))
+        assert "אלי דריקס" not in result
+
+    def test_best_scorers_in_one_game_no_results_for_high_threshold(self, maccabi_games):
+        # No player scores 5+ in any fixture game
+        result = maccabi_games.players.best_scorers_in_one_game(score_at_least=5)
+        assert len(result) == 0
+
+
+class TestBestAssistersInOneGame:
+    def test_best_assisters_in_one_game_with_two_assists(self, maccabi_games):
+        # assist_at_least=2: חיים רביבו assisted 2 in games 1, 4, and 5
+        result = dict(maccabi_games.players.best_assisters_in_one_game(assist_at_least=2))
+        assert result["חיים רביבו"] == 3
+
+    def test_best_assisters_in_one_game_excludes_below_threshold(self, maccabi_games):
+        # assist_at_least=2: no other player has 2+ assists in one game
+        result = dict(maccabi_games.players.best_assisters_in_one_game(assist_at_least=2))
+        assert len(result) == 1  # Only חיים רביבו
+
+
 class TestOwnGoals:
     def test_best_scorers_excludes_own_goals(self, maccabi_games):
         scorers = dict(maccabi_games.players.best_scorers)

--- a/packages/maccabistats/tests/test_players.py
+++ b/packages/maccabistats/tests/test_players.py
@@ -159,10 +159,27 @@ class TestBestScorersInOneGame:
         assert result["אבי נמני"] == 6
         assert result["אלי דריקס"] == 2
 
-    def test_best_scorers_in_one_game_excludes_own_goals(self, maccabi_games):
-        # בני טבק scores 1 own goal in game 9 — should not qualify for score_at_least=1
-        result = dict(maccabi_games.players.best_scorers_in_one_game(score_at_least=1))
-        assert "בני טבק" not in result
+    def test_best_scorers_in_one_game_excludes_own_goals(self):
+        # Build a minimal game where שייע גלזר scores only an own goal — should not qualify
+        import datetime
+        from maccabistats.models.player_game_events import GoalTypes
+        from maccabistats.models.team_in_game import TeamInGame
+        from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
+        from game_fixtures import _player, _lineup, _goal, _game
+        from players_data_fixtures import create_stub_players_data
+
+        game = _game(
+            competition="ליגת העל", fixture="מחזור1", season="2020/21",
+            date=datetime.datetime(2020, 1, 1),
+            stadium="בלומפילד", referee="ref",
+            home_team=TeamInGame("מכבי תל אביב", "מאמן", 0, [
+                _player("שייע גלזר", 5, [_lineup(), _goal(30, GoalTypes.OWN_GOAL)]),
+            ]),
+            away_team=TeamInGame("יריב", "מאמן", 1, [_player("שוער", 1, [_lineup()])]),
+        )
+        games = MaccabiGamesStats([game], players_data=create_stub_players_data())
+        result = dict(games.players.best_scorers_in_one_game(score_at_least=1))
+        assert "שייע גלזר" not in result
 
     def test_best_scorers_in_one_game_is_sorted(self, maccabi_games):
         # Result must be sorted descending by count (most_common contract)

--- a/packages/maccabistats/tests/test_players.py
+++ b/packages/maccabistats/tests/test_players.py
@@ -153,6 +153,22 @@ class TestBestScorersInOneGame:
         result = maccabi_games.players.best_scorers_in_one_game(score_at_least=5)
         assert len(result) == 0
 
+    def test_best_scorers_in_one_game_with_one_goal(self, maccabi_games):
+        # score_at_least=1: אבי נמני scores in games 1,3,4,5,7,8 = 6; אלי דריקס in games 1,4 = 2
+        result = dict(maccabi_games.players.best_scorers_in_one_game(score_at_least=1))
+        assert result["אבי נמני"] == 6
+        assert result["אלי דריקס"] == 2
+
+    def test_best_scorers_in_one_game_excludes_own_goals(self, maccabi_games):
+        # בני טבק scores 1 own goal in game 9 — should not qualify for score_at_least=1
+        result = dict(maccabi_games.players.best_scorers_in_one_game(score_at_least=1))
+        assert "בני טבק" not in result
+
+    def test_best_scorers_in_one_game_is_sorted(self, maccabi_games):
+        # Result must be sorted descending by count (most_common contract)
+        result = maccabi_games.players.best_scorers_in_one_game(score_at_least=2)
+        assert result[0] == ("אבי נמני", 2)
+
 
 class TestBestAssistersInOneGame:
     def test_best_assisters_in_one_game_with_two_assists(self, maccabi_games):
@@ -163,7 +179,12 @@ class TestBestAssistersInOneGame:
     def test_best_assisters_in_one_game_excludes_below_threshold(self, maccabi_games):
         # assist_at_least=2: no other player has 2+ assists in one game
         result = dict(maccabi_games.players.best_assisters_in_one_game(assist_at_least=2))
-        assert len(result) == 1  # Only חיים רביבו
+        assert "אבי נמני" not in result
+
+    def test_best_assisters_in_one_game_with_one_assist(self, maccabi_games):
+        # assist_at_least=1: חיים רביבו assists in games 1,4,5,7,8 = 5 qualifying games
+        result = dict(maccabi_games.players.best_assisters_in_one_game(assist_at_least=1))
+        assert result["חיים רביבו"] == 5
 
 
 class TestOwnGoals:

--- a/packages/maccabistats/tests/test_players.py
+++ b/packages/maccabistats/tests/test_players.py
@@ -159,26 +159,9 @@ class TestBestScorersInOneGame:
         assert result["אבי נמני"] == 6
         assert result["אלי דריקס"] == 2
 
-    def test_best_scorers_in_one_game_excludes_own_goals(self):
-        # Build a minimal game where שייע גלזר scores only an own goal — should not qualify
-        import datetime
-        from maccabistats.models.player_game_events import GoalTypes
-        from maccabistats.models.team_in_game import TeamInGame
-        from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
-        from game_fixtures import _player, _lineup, _goal, _game
-        from players_data_fixtures import create_stub_players_data
-
-        game = _game(
-            competition="ליגת העל", fixture="מחזור1", season="2020/21",
-            date=datetime.datetime(2020, 1, 1),
-            stadium="בלומפילד", referee="ref",
-            home_team=TeamInGame("מכבי תל אביב", "מאמן", 0, [
-                _player("שייע גלזר", 5, [_lineup(), _goal(30, GoalTypes.OWN_GOAL)]),
-            ]),
-            away_team=TeamInGame("יריב", "מאמן", 1, [_player("שוער", 1, [_lineup()])]),
-        )
-        games = MaccabiGamesStats([game], players_data=create_stub_players_data())
-        result = dict(games.players.best_scorers_in_one_game(score_at_least=1))
+    def test_best_scorers_in_one_game_excludes_own_goals(self, own_goal_games):
+        # שייע גלזר scores only an own goal in OWN_GOAL_GAME — should not qualify
+        result = dict(own_goal_games.players.best_scorers_in_one_game(score_at_least=1))
         assert "שייע גלזר" not in result
 
     def test_best_scorers_in_one_game_is_sorted(self, maccabi_games):


### PR DESCRIPTION
## Summary
- Add `best_scorers_in_one_game(score_at_least)` to `MaccabiGamesPlayersStats` — ranks players by how many games they scored at least N goals (e.g., `score_at_least=3` for hattrick kings)
- Add `best_assisters_in_one_game(assist_at_least)` — same pattern for assists
- Both return `List[PlayerStats]` sorted descending, consistent with all existing player stat methods

## Test plan
- [x] 9 new tests covering: happy path, below-threshold exclusion, high-threshold empty result, `score/assist_at_least=1` boundary, own-goal exclusion, and ordering
- [x] Added Maccabi own goal to game fixture to cover the own-goal subtraction branch
- [x] All 36 tests pass

Trello: https://trello.com/c/oabDCtfx/361

🤖 Generated with [Claude Code](https://claude.com/claude-code)