### PR TITLE
docs: add Trello card lifecycle and PR workflow guidelines

### DIFF
--- a/.claude/trello_board_structure.md
+++ b/.claude/trello_board_structure.md
@@ -67,6 +67,19 @@ These layers can disagree. For example, wikitext may store data in the correct o
 
 1. **Adding tasks**: Tell Claude to add a card — it goes to Inbox with auto-labels.
 2. **Triage**: Review Inbox periodically, move cards to Next Up or archive.
-3. **Pick up work**: Claude checks cards with `Claude` label in Next Up.
+3. **Pick up work**: User tells Claude which card to take.
 4. **Complete**: Claude moves card to Done with a comment (commit reference if applicable).
 5. **Cleanup**: Archive Done cards monthly.
+
+## Card Lifecycle (Claude)
+
+When told to take a card:
+1. Fetch the card, read its description and checklist
+2. Move card to **In Progress**
+3. Do the work
+4. **If blocked:** comment on the card describing the blocker; stay In Progress (do NOT move to Waiting)
+5. **If a significant decision changes direction mid-work:** add a comment immediately
+6. **When PR is created:** comment on the card with the PR link; stay In Progress
+7. **When PR is merged:** move card to **Done**, add a summary comment with PR/commit link and any key decisions not already commented
+
+**Commenting rule:** Minor decisions → summarize in the final Done comment. Major direction changes → comment immediately when they happen.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,31 @@ Use `utf-8-sig` encoding when writing CSV/TXT/JSON files with Hebrew text that m
 ### Never use pywikibot's file_page.upload() — use requests directly
 Produces malformed HTTP (bad MIME headers, LF-only line endings) → Apache 400. Use `requests.post(..., files=...)` with pywikibot session cookies. Reference: `upload_basketball_tickets.py` → `_upload_file_via_requests()`.
 
-## 5. Reference Files
+## 5. Workflows
+
+### PR Workflow (all PRs)
+
+**Before creating any PR:**
+- No merge conflicts with `master`
+- `uv run pytest` passes
+- `uv run mypy` has no new type errors
+- PR description includes what changed and why
+
+**After PR is created:**
+- Monitor CI — if checks fail, fix and push before notifying the user
+- User reviews and merges
+
+### maccabistats Version Bump (maccabistats PRs only)
+
+Any PR touching `packages/maccabistats/` must also include, before the PR is created:
+
+1. **Version bump** — update `packages/maccabistats/src/maccabistats/version.py`:
+   - New feature or fix → increment minor version (`2.X` → `2.X+1`)
+   - Small patch → increment patch version (`2.X.Y` → `2.X.Y+1`)
+2. **Changelog entry** — prepend a new entry to `packages/maccabistats/CHANGELOG.md` with the new version and a short description
+3. **Commit both** on the feature branch (e.g. `bump: maccabistats 2.61`)
+
+## 6. Reference Files
 - `.claude/maccabipedia_structure_knowledge.md` — Game pages, player pages, templates, Cargo API
 - `.claude/maccabipedia_research_sources.md` — External data sources: rosters, match results, historical records, photos, video
 - `.claude/maccabistats_knowledge.md` — maccabistats Python package API reference


### PR DESCRIPTION
## Summary
- Add full Trello card lifecycle to `.claude/trello_board_structure.md`: take → in progress → PR → merge → done, with commenting rules
- Add generic PR workflow to `CLAUDE.md` (pre-checks: no conflicts, tests pass, mypy; CI monitoring after PR creation)
- Add maccabistats-specific version bump + changelog requirement for any PR touching `packages/maccabistats/`

## Why
Codifying these workflows so Claude follows them consistently across sessions without needing reminders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)