### PR TITLE
fix: treat HTTP 400 from oEmbed as broken video

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
@@ -140,7 +140,7 @@ async def is_video_broken(session: aiohttp.ClientSession, url: str) -> bool:
         logger.debug("No oEmbed endpoint for %s — skipping", url)
         return False
     async with session.get(oembed) as resp:
-        if resp.status in (404, 401):
+        if resp.status in (400, 401, 404):
             return True
         if resp.status != 200:
             logger.warning("Unexpected oEmbed status %s for %s — skipping", resp.status, url)

--- a/packages/maccabipediabot/tests/maintenance/videos/test_find_broken_videos.py
+++ b/packages/maccabipediabot/tests/maintenance/videos/test_find_broken_videos.py
@@ -189,6 +189,11 @@ def _make_mock_session(status: int) -> Mock:
     return mock_session
 
 
+def test_is_video_broken_returns_true_on_400():
+    result = asyncio.run(is_video_broken(_make_mock_session(400), "https://www.youtube.com/watch?v=broken"))
+    assert result is True
+
+
 def test_is_video_broken_returns_true_on_404():
     result = asyncio.run(is_video_broken(_make_mock_session(404), "https://www.youtube.com/watch?v=broken"))
     assert result is True


### PR DESCRIPTION
## Summary
- YouTube oEmbed returns 400 for unavailable/deleted videos, not just 404
- Discovered from a live CI run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)