### PR TITLE
fix: preserve newline when clearing video field in template

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
@@ -191,7 +191,7 @@ def _remove_broken_link(site: pw.Site, video: BrokenVideo) -> bool:
     if not tmpl.has(field) or not str(tmpl.get(field).value).strip():
         return False
 
-    tmpl.get(field).value = ""
+    tmpl.get(field).value = "\n"
     page.text = str(parsed)
     try:
         page.save(summary="MaccabiBot - Remove broken video link", bot=True)


### PR DESCRIPTION
## Summary
- Setting a template field value to "" in mwparserfromhell ate the trailing newline, merging two parameters onto one line
- Fix: set to "\n" instead

Discovered from a live page: the cleared field merged with the next field on the same line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)