### PR TITLE
fix(maintenance): use HTML inline links in Telegram removal report

### DIFF
--- a/.github/workflows/find_broken_videos.yaml
+++ b/.github/workflows/find_broken_videos.yaml
@@ -42,6 +42,7 @@ jobs:
         with:
           to: ${{ secrets.MACCABIPEDIA_BROKEN_VIDEOS_TELEGRAM_TO }}
           token: ${{ secrets.MACCABIPEDIA_ERRORS_TELEGRAM_TOKEN }}
+          format: HTML
           message: ${{ steps.report.outputs.content }}
 
   workflow-keepalive:

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
@@ -87,7 +87,7 @@ def format_removal_report(removed: list[BrokenVideo], report_date: date) -> str:
     for page_name, videos in sorted(by_page.items()):
         page_url = _page_url(page_name)
         video_links = ", ".join(f'<a href="{v.url}">{v.video_type}</a>' for v in videos)
-        lines.append(f'({video_links})\u200b <a href="{page_url}">{page_name}</a>')
+        lines.append(f'\u200f<a href="{page_url}">{page_name}</a> ({video_links})\u200b')
     return "\n".join(lines)
 
 

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
@@ -87,7 +87,7 @@ def format_removal_report(removed: list[BrokenVideo], report_date: date) -> str:
     for page_name, videos in sorted(by_page.items()):
         page_url = _page_url(page_name)
         video_links = ", ".join(f'<a href="{v.url}">{v.video_type}</a>' for v in videos)
-        lines.append(f'<a href="{page_url}">{page_name}</a> ({video_links})\u200b')
+        lines.append(f'({video_links})\u200b <a href="{page_url}">{page_name}</a>')
     return "\n".join(lines)
 
 

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
@@ -88,7 +88,7 @@ def format_removal_report(removed: list[BrokenVideo], report_date: date) -> str:
         url = _page_url(page_name)
         lines.append(f'\n<a href="{url}">{page_name}</a>')
         for v in videos:
-            lines.append(f"  • {v.video_type}: {v.url}")
+            lines.append(f'  • <a href="{v.url}">{v.video_type}</a>')
     return "\n".join(lines)
 
 

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
@@ -84,11 +84,10 @@ def format_removal_report(removed: list[BrokenVideo], report_date: date) -> str:
         by_page.setdefault(v.page_name, []).append(v)
 
     lines = [f"הוסרו {len(removed)} קישורי וידאו שבורים — {report_date}"]
-    for i, (page_name, videos) in enumerate(sorted(by_page.items()), start=1):
-        url = _page_url(page_name)
-        lines.append(f'\n{i}. <a href="{url}">{page_name}</a>')
-        for v in videos:
-            lines.append(f'  • <a href="{v.url}">{v.video_type}</a>\u200b')
+    for page_name, videos in sorted(by_page.items()):
+        page_url = _page_url(page_name)
+        video_links = ", ".join(f'<a href="{v.url}">{v.video_type}</a>' for v in videos)
+        lines.append(f'<a href="{page_url}">{page_name}</a> ({video_links})\u200b')
     return "\n".join(lines)
 
 

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
@@ -84,11 +84,11 @@ def format_removal_report(removed: list[BrokenVideo], report_date: date) -> str:
         by_page.setdefault(v.page_name, []).append(v)
 
     lines = [f"הוסרו {len(removed)} קישורי וידאו שבורים — {report_date}"]
-    for page_name, videos in sorted(by_page.items()):
+    for i, (page_name, videos) in enumerate(sorted(by_page.items()), start=1):
         url = _page_url(page_name)
-        lines.append(f'\n<a href="{url}">{page_name}</a>')
+        lines.append(f'\n{i}. <a href="{url}">{page_name}</a>')
         for v in videos:
-            lines.append(f'  • <a href="{v.url}">{v.video_type}</a>')
+            lines.append(f'  • <a href="{v.url}">{v.video_type}</a>\u200b')
     return "\n".join(lines)
 
 

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/find_broken_videos.py
@@ -85,8 +85,8 @@ def format_removal_report(removed: list[BrokenVideo], report_date: date) -> str:
 
     lines = [f"הוסרו {len(removed)} קישורי וידאו שבורים — {report_date}"]
     for page_name, videos in sorted(by_page.items()):
-        lines.append(f"\n{page_name}")
-        lines.append(_page_url(page_name))
+        url = _page_url(page_name)
+        lines.append(f'\n<a href="{url}">{page_name}</a>')
         for v in videos:
             lines.append(f"  • {v.video_type}: {v.url}")
     return "\n".join(lines)

--- a/packages/maccabipediabot/tests/maintenance/videos/test_find_broken_videos.py
+++ b/packages/maccabipediabot/tests/maintenance/videos/test_find_broken_videos.py
@@ -151,7 +151,7 @@ def test_format_removal_report_contains_count_and_wiki_url():
     report = format_removal_report(removed, date(2026, 4, 9))
     assert "הוסרו 1" in report
     assert "2026-04-09" in report
-    assert "https://www.maccabipedia.co.il/" in report
+    assert '<a href="https://www.maccabipedia.co.il/' in report
     assert "16-09-1999" in report
     assert "משחק מלא" in report
     assert "https://www.youtube.com/watch?v=JwUrFyR75sY" in report
@@ -166,7 +166,9 @@ def test_format_removal_report_url_encodes_special_chars():
         )
     ]
     report = format_removal_report(removed, date(2026, 4, 9))
-    assert '"' not in report.split("https://www.maccabipedia.co.il/")[1].split("\n")[0]
+    # Extract href URL — between href=" and the closing "
+    href_url = report.split('href="')[1].split('"')[0]
+    assert '"' not in href_url
 
 
 def test_oembed_endpoint_returns_none_for_unknown_domain():


### PR DESCRIPTION
## Summary
- `format_removal_report` now emits `<a href="url">page name</a>` instead of two separate lines
- Workflow passes `format: HTML` to `appleboy/telegram-action` so Telegram renders the link inline
- Updated tests to assert the HTML link format

🤖 Generated with [Claude Code](https://claude.com/claude-code)