### PR TITLE
fix(maintenance): correct tracking category name

### DIFF
--- a/.claude/maccabipedia_structure_knowledge.md
+++ b/.claude/maccabipedia_structure_knowledge.md
@@ -140,7 +140,7 @@ Each event is one pipe-separated entry in the `|אירועי שחקנים=` para
 **The single-colon trap:**  
 A single `:` before the minute (e.g. `גול-נגיחה:67`) instead of `::` (e.g. `גול-נגיחה::67`) causes the template to tag the page as having illegal events, even though the type name is valid. Always use `::` between every field.
 
-**Tracking category:** Pages with bad events are added to the "אירועי שחקנים לא חוקיים" tracking category.
+**Tracking category:** Pages with bad events are added to the `משחקים המכילים אירוע לא תקין` tracking category (populated by the `הזנת אירועי משחק` template's `#ברירת מחדל` branch for unknown main event types).
 
 ## 10. Basketball Player Stats (`|שחקנים מכבי=` / `|שחקנים יריבה=`)
 

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/events/find_illegal_events.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/events/find_illegal_events.py
@@ -28,7 +28,7 @@ from maccabipediabot.common.maccabistats_player_event import PlayerEvent
 logger = logging.getLogger(__name__)
 
 WIKI_BASE_URL = "https://www.maccabipedia.co.il"
-TRACKING_CATEGORY = "אירועי שחקנים לא חוקיים"
+TRACKING_CATEGORY = "משחקים המכילים אירוע לא תקין"
 FOOTBALL_TEMPLATE = "קטלוג משחקים"
 EVENTS_PARAM = "אירועי שחקנים"
 

--- a/packages/maccabipediabot/tests/maintenance/events/test_find_illegal_events.py
+++ b/packages/maccabipediabot/tests/maintenance/events/test_find_illegal_events.py
@@ -13,7 +13,7 @@ from maccabipediabot.maintenance.events.find_illegal_events import (
 # ── Task 1: Module skeleton ──────────────────────────────────────────────────
 
 def test_module_imports_cleanly():
-    assert TRACKING_CATEGORY == "אירועי שחקנים לא חוקיים"
+    assert TRACKING_CATEGORY == "משחקים המכילים אירוע לא תקין"
     assert ROW_SEPARATOR == ","
 
 


### PR DESCRIPTION
## Summary
- Fixes the `TRACKING_CATEGORY` constant: the real category populated by the `הזנת אירועי משחק` template is `משחקים המכילים אירוע לא תקין`, not `אירועי שחקנים לא חוקיים` (which doesn't exist).
- Discovered during e2e verification by reading the template source directly.
- Also corrects the category name in `.claude/maccabipedia_structure_knowledge.md`.

## Test plan
- [ ] Trigger `Find Illegal Player Events` via `workflow_dispatch` after merge — should find the test page and send Telegram message

🤖 Generated with [Claude Code](https://claude.com/claude-code)