### PR TITLE
fix(ci): send illegal events report to correct Telegram channel

### DIFF
--- a/.github/workflows/find_illegal_events.yaml
+++ b/.github/workflows/find_illegal_events.yaml
@@ -40,7 +40,7 @@ jobs:
         if: steps.report.outputs.has_content == 'true'
         uses: appleboy/telegram-action@v1.0.1
         with:
-          to: ${{ secrets.MACCABIPEDIA_ERRORS_TELEGRAM_TO }}
+          to: ${{ secrets.MACCABIPEDIA_BROKEN_VIDEOS_TELEGRAM_TO }}
           token: ${{ secrets.MACCABIPEDIA_ERRORS_TELEGRAM_TOKEN }}
           format: HTML
           message: ${{ steps.report.outputs.content }}


### PR DESCRIPTION
## Summary
- Uses `MACCABIPEDIA_BROKEN_VIDEOS_TELEGRAM_TO` (the general errors channel) instead of `MACCABIPEDIA_ERRORS_TELEGRAM_TO` for the illegal events report, matching the broken-videos workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)