### PR TITLE
fix(maintenance): iterate all three illegal events tracking categories

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/events/find_illegal_events.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/events/find_illegal_events.py
@@ -28,7 +28,11 @@ from maccabipediabot.common.maccabistats_player_event import PlayerEvent
 logger = logging.getLogger(__name__)
 
 WIKI_BASE_URL = "https://www.maccabipedia.co.il"
-TRACKING_CATEGORY = "משחקים המכילים אירוע לא תקין"
+TRACKING_CATEGORIES = [
+    "משחקים המכילים אירוע לא תקין",     # unknown main event type
+    "שחקנים עם תיוג שער לא חוקי",        # unknown goal sub-type
+    "שחקנים עם תיוג בישול לא חוקי",      # unknown assist sub-type
+]
 FOOTBALL_TEMPLATE = "קטלוג משחקים"
 EVENTS_PARAM = "אירועי שחקנים"
 
@@ -224,8 +228,14 @@ def main() -> None:
     pw.config.verbose_output = False
     site = get_site()
 
-    pages = fetch_category_pages(site, TRACKING_CATEGORY)
-    logger.info("Found %d pages in tracking category", len(pages))
+    seen: set[str] = set()
+    pages: list[pw.Page] = []
+    for category in TRACKING_CATEGORIES:
+        for page in fetch_category_pages(site, category):
+            if page.title() not in seen:
+                seen.add(page.title())
+                pages.append(page)
+    logger.info("Found %d pages across tracking categories", len(pages))
 
     if not pages:
         return

--- a/packages/maccabipediabot/tests/maintenance/events/test_find_illegal_events.py
+++ b/packages/maccabipediabot/tests/maintenance/events/test_find_illegal_events.py
@@ -5,7 +5,7 @@ from maccabipediabot.maintenance.events.find_illegal_events import (
     AutoFixedPage,
     NeedsManualReviewPage,
     ROW_SEPARATOR,
-    TRACKING_CATEGORY,
+    TRACKING_CATEGORIES,
     _page_url,
 )
 
@@ -13,7 +13,9 @@ from maccabipediabot.maintenance.events.find_illegal_events import (
 # ── Task 1: Module skeleton ──────────────────────────────────────────────────
 
 def test_module_imports_cleanly():
-    assert TRACKING_CATEGORY == "משחקים המכילים אירוע לא תקין"
+    assert "משחקים המכילים אירוע לא תקין" in TRACKING_CATEGORIES
+    assert "שחקנים עם תיוג שער לא חוקי" in TRACKING_CATEGORIES
+    assert "שחקנים עם תיוג בישול לא חוקי" in TRACKING_CATEGORIES
     assert ROW_SEPARATOR == ","
 
 


### PR DESCRIPTION
## Summary
- Replaces single `TRACKING_CATEGORY` with `TRACKING_CATEGORIES` list covering all three categories populated by the `הזנת אירועי משחק` template:
  - `משחקים המכילים אירוע לא תקין` — unknown main event type
  - `שחקנים עם תיוג שער לא חוקי` — unknown goal sub-type
  - `שחקנים עם תיוג בישול לא חוקי` — unknown assist sub-type
- Pages appearing in multiple categories are deduplicated by title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)