### PR TITLE
fix(football): propagate players_data when slicing last game stats

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/football/upload_last_game_to_maccabipedia.py
+++ b/packages/maccabipediabot/src/maccabipediabot/football/upload_last_game_to_maccabipedia.py
@@ -6,9 +6,10 @@ from maccabistats import load_from_maccabisite_source
 logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
 
 from maccabipediabot.football.gamesbot import upload_games_to_maccabipedia
+from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
 
 
-def loading_last_game_from_maccabi_site():
+def loading_last_game_from_maccabi_site() -> MaccabiGamesStats:
     games_from_maccabi_tlv_site = load_from_maccabisite_source()
     logging.info(
         f'Loaded games from maccabi tlv site: {games_from_maccabi_tlv_site.first_game_date} to {games_from_maccabi_tlv_site.last_game_date}')

--- a/packages/maccabipediabot/src/maccabipediabot/football/upload_last_game_to_maccabipedia.py
+++ b/packages/maccabipediabot/src/maccabipediabot/football/upload_last_game_to_maccabipedia.py
@@ -6,14 +6,15 @@ from maccabistats import load_from_maccabisite_source
 logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.DEBUG)
 
 from maccabipediabot.football.gamesbot import upload_games_to_maccabipedia
-from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
 
 
-def loading_last_game_from_maccabi_site() -> MaccabiGamesStats:
+def loading_last_game_from_maccabi_site():
     games_from_maccabi_tlv_site = load_from_maccabisite_source()
     logging.info(
         f'Loaded games from maccabi tlv site: {games_from_maccabi_tlv_site.first_game_date} to {games_from_maccabi_tlv_site.last_game_date}')
-    return MaccabiGamesStats([games_from_maccabi_tlv_site[-1]])
+    return games_from_maccabi_tlv_site.create_maccabi_games_stats_with_filtered_games(
+        [games_from_maccabi_tlv_site.games[-1]], 'Last game'
+    )
 
 
 if __name__ == '__main__':

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -46,11 +46,8 @@ logger = logging.getLogger(__name__)
 class MaccabiGamesStats:
     _DEFAULT_DESCRIPTION = 'All games'
 
-    def __init__(self, games: List[GameData], description: str = None,
-                 players_data: MaccabiPediaPlayers = None,  # required: always pass players_data
-                 ) -> None:
-        if players_data is None:
-            raise TypeError("players_data is required — always pass a MaccabiPediaPlayers instance")
+    def __init__(self, games: List[GameData], description: str = None, *,
+                 players_data: MaccabiPediaPlayers) -> None:
         self.games: List[GameData] = sorted(games, key=lambda g: g.date)  # Sort the games by date
         self.description = description or self._DEFAULT_DESCRIPTION
         self.players_data = players_data

--- a/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
+++ b/packages/maccabistats/src/maccabistats/stats/maccabi_games_stats.py
@@ -47,7 +47,10 @@ class MaccabiGamesStats:
     _DEFAULT_DESCRIPTION = 'All games'
 
     def __init__(self, games: List[GameData], description: str = None,
-                 players_data: MaccabiPediaPlayers = None) -> None:
+                 players_data: MaccabiPediaPlayers = None,  # required: always pass players_data
+                 ) -> None:
+        if players_data is None:
+            raise TypeError("players_data is required — always pass a MaccabiPediaPlayers instance")
         self.games: List[GameData] = sorted(games, key=lambda g: g.date)  # Sort the games by date
         self.description = description or self._DEFAULT_DESCRIPTION
         self.players_data = players_data

--- a/packages/maccabistats/tests/test_players_data_pickle.py
+++ b/packages/maccabistats/tests/test_players_data_pickle.py
@@ -182,5 +182,5 @@ def test_filter_chain_preserves_players_data(monkeypatch):
 def test_players_data_required_for_player_stats():
     """Without players_data, accessing player stats should fail."""
     games = [_make_game(datetime(2024, 9, 1))]
-    with pytest.raises((AttributeError, TypeError)):
+    with pytest.raises(TypeError):
         MaccabiGamesStats(games)


### PR DESCRIPTION
## Summary
- `upload_last_game_to_maccabipedia` was constructing a bare `MaccabiGamesStats([last_game])` without forwarding `players_data`, causing `AttributeError: 'NoneType' object has no attribute 'players_dates'` in CI
- Fixed by using `create_maccabi_games_stats_with_filtered_games` which correctly inherits `players_data` from the parent stats object
- Added a `TypeError` guard in `MaccabiGamesStats.__init__` so any future callsite that omits `players_data` gets a clear, immediate error instead of a confusing `AttributeError` deep inside init

## Test Plan
- [ ] All 233 existing tests pass
- [ ] CI upload-last-game job no longer throws `AttributeError`