### PR TITLE
feat(maintenance): purge main page every 3 hours

### DIFF
--- a/.github/workflows/purge_main_page.yaml
+++ b/.github/workflows/purge_main_page.yaml
@@ -1,0 +1,33 @@
+name: Purge Main Page
+
+on:
+  schedule:
+    - cron: "0 */3 * * *"
+  workflow_dispatch:
+
+jobs:
+  purge-main-page:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          architecture: x64
+      - uses: astral-sh/setup-uv@v6
+      - name: Install dependencies
+        run: uv sync
+      - name: Purge main page
+        env:
+          PYWIKIBOT_DIR: ${{ github.workspace }}/packages/maccabipediabot/src/maccabipediabot/pywikibot_configs
+          MACCABIPEDIA_BOT_USERNAME: ${{ secrets.MACCABIPEDIA_BOT_USERNAME }}
+          MACCABIPEDIA_BOT_PASSWORD: ${{ secrets.MACCABIPEDIA_BOT_PASSWORD }}
+        run: uv run python -m maccabipediabot.maintenance.purge_main_page
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/purge_main_page.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/purge_main_page.py
@@ -13,7 +13,10 @@ def purge_main_page() -> None:
     site = get_site()
     page = pw.Page(site, MAIN_PAGE_TITLE)
     logging.info(f'Purging page: {page.title()}')
-    page.purge()
+    success = page.purge()
+    if not success:
+        raise RuntimeError(f'Failed to purge {page.title()}')
+    logging.info('Purge successful')
 
 
 if __name__ == '__main__':

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/purge_main_page.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/purge_main_page.py
@@ -1,0 +1,20 @@
+import logging
+
+import pywikibot as pw
+
+from maccabipediabot.common.wiki_login import get_site
+
+logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s', level=logging.INFO)
+
+MAIN_PAGE_TITLE = "עמוד ראשי"
+
+
+def purge_main_page() -> None:
+    site = get_site()
+    page = pw.Page(site, MAIN_PAGE_TITLE)
+    logging.info(f'Purging page: {page.title()}')
+    page.purge()
+
+
+if __name__ == '__main__':
+    purge_main_page()


### PR DESCRIPTION
## Summary
- New scheduled workflow `purge_main_page.yaml` runs every 3 hours (and on manual dispatch)
- Calls a new maintenance script that purges `עמוד ראשי` so rotated content refreshes

Closes [Trello #521](https://trello.com/c/1fHfBvre).

## Test plan
- [ ] Manually dispatch the workflow in Actions and confirm it completes green
- [ ] Confirm the main page's rotated sections change after the purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)