### PR TITLE
feat(football): purge main page after uploading new games

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/football/gamesbot.py
+++ b/packages/maccabipediabot/src/maccabipediabot/football/gamesbot.py
@@ -362,6 +362,10 @@ def upload_games_to_maccabipedia(maccabi_games_to_add: MaccabiGamesStats):
 
     logging.info("Finished adding new games.")
 
+    # The main page shows the latest 5 games list, so purge it too
+    if all_pages_to_purge:
+        all_pages_to_purge.add("עמוד ראשי")
+
     # Batch purge all collected pages at the end
     if SHOULD_SAVE and SHOULD_PURGE_RELATED_PAGES:
         purge_pages_batch(all_pages_to_purge)

--- a/packages/maccabipediabot/src/maccabipediabot/volleyball/gamesbot_volleyball.py
+++ b/packages/maccabipediabot/src/maccabipediabot/volleyball/gamesbot_volleyball.py
@@ -266,6 +266,10 @@ def create_or_update_volleyball_game_pages(games_to_add: List[VolleyballGame]):
 
     logging.info("Finished adding new games.")
 
+    # The main page shows the latest 5 games list, so purge it too
+    if all_pages_to_purge:
+        all_pages_to_purge.add("עמוד ראשי")
+
     # Batch purge all collected pages at the end
     if SHOULD_SAVE and SHOULD_PURGE_RELATED_PAGES:
         purge_pages_batch(all_pages_to_purge)


### PR DESCRIPTION
## Summary
- Add `עמוד ראשי` to the post-upload purge set in both football and volleyball upload flows
- The main page displays the latest 5 games list, so it needs to be refreshed when new games are uploaded

Closes Trello card [QmU1BwC4](https://trello.com/c/QmU1BwC4).

## Test plan
- [ ] Upload a new game via the football bot and verify the main page list updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)