### PR TITLE
fix(basketball): route euroleague fetch through ScrapingBee on CI

### DIFF
--- a/.github/workflows/basketball_games_uploader.yaml
+++ b/.github/workflows/basketball_games_uploader.yaml
@@ -23,6 +23,8 @@ jobs:
             --season latest --limit 1 --output /tmp/basket.json
 
       - name: Crawl Euroleague (latest 1 game)
+        env:
+          SCRAPINGBEE_API_KEY: ${{ secrets.SCRAPINGBEE_API_KEY }}
         run: |
           uv run python -m maccabipediabot.basketball.crawl_euroleague \
             --season latest --limit 1 --output /tmp/euroleague.json

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_euroleague.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_euroleague.py
@@ -6,6 +6,7 @@ or headless browser.
 import argparse
 import json
 import logging
+import os
 import time
 from datetime import datetime
 from pathlib import Path
@@ -53,6 +54,7 @@ HTTP_HEADERS = {
 }
 _FETCH_RETRY_STATUSES = {429, 502, 503, 504}
 _FETCH_MAX_ATTEMPTS = 4
+_SCRAPINGBEE_API_URL = "https://app.scrapingbee.com/api/v1/"
 COMPETITION_NAME_HE = "יורוליג"
 MACCABI_TEAM_NAME_ENG = "Maccabi Rapyd Tel Aviv"
 GAME_URL_PREFIX = "https://www.euroleaguebasketball.net"
@@ -68,11 +70,23 @@ def extract_next_data(html: str) -> dict[str, Any]:
 
 
 def fetch_html(url: str) -> str:
-    """GET `url` with browser-like headers and retry on 429/5xx.
+    """GET `url`, routing through ScrapingBee when SCRAPINGBEE_API_KEY is set.
 
-    Vercel's bot detection sometimes greets cloud IPs (incl. GitHub Actions) with
-    429s; a few retries with backoff usually clears it. Respects Retry-After.
+    Vercel's bot wall fires a JS challenge for any datacenter IP (GitHub Actions,
+    cloud, etc.), so cloud runs must go through a residential-IP proxy. Locally
+    (residential IP) the env var is unset and we fetch direct, with retry on
+    429/5xx as a safety net.
     """
+    api_key = os.environ.get("SCRAPINGBEE_API_KEY")
+    if api_key:
+        resp = requests.get(
+            _SCRAPINGBEE_API_URL,
+            params={"api_key": api_key, "url": url},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        return resp.text
+
     last_resp: requests.Response | None = None
     for attempt in range(1, _FETCH_MAX_ATTEMPTS + 1):
         resp = requests.get(url, headers=HTTP_HEADERS, timeout=30)

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_euroleague.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_euroleague.py
@@ -6,6 +6,7 @@ or headless browser.
 import argparse
 import json
 import logging
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -34,10 +35,24 @@ TEAM_RESULTS_URL = (
 )
 HTTP_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                  "(KHTML, like Gecko) Chrome/124.0 Safari/537.36",
+                  "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,"
+              "image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
     "Accept-Language": "en-US,en;q=0.9",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
+    "Sec-Ch-Ua": '"Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"',
+    "Sec-Ch-Ua-Mobile": "?0",
+    "Sec-Ch-Ua-Platform": '"Windows"',
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Upgrade-Insecure-Requests": "1",
 }
+_FETCH_RETRY_STATUSES = {429, 502, 503, 504}
+_FETCH_MAX_ATTEMPTS = 4
 COMPETITION_NAME_HE = "יורוליג"
 MACCABI_TEAM_NAME_ENG = "Maccabi Rapyd Tel Aviv"
 GAME_URL_PREFIX = "https://www.euroleaguebasketball.net"
@@ -53,9 +68,28 @@ def extract_next_data(html: str) -> dict[str, Any]:
 
 
 def fetch_html(url: str) -> str:
-    resp = requests.get(url, headers=HTTP_HEADERS, timeout=30)
-    resp.raise_for_status()
-    return resp.text
+    """GET `url` with browser-like headers and retry on 429/5xx.
+
+    Vercel's bot detection sometimes greets cloud IPs (incl. GitHub Actions) with
+    429s; a few retries with backoff usually clears it. Respects Retry-After.
+    """
+    last_resp: requests.Response | None = None
+    for attempt in range(1, _FETCH_MAX_ATTEMPTS + 1):
+        resp = requests.get(url, headers=HTTP_HEADERS, timeout=30)
+        if resp.status_code not in _FETCH_RETRY_STATUSES:
+            resp.raise_for_status()
+            return resp.text
+        last_resp = resp
+        if attempt == _FETCH_MAX_ATTEMPTS:
+            break
+        retry_after = resp.headers.get("Retry-After")
+        delay = float(retry_after) if retry_after and retry_after.isdigit() else 2 ** attempt
+        logger.warning("fetch %s returned %d; retrying in %.1fs (attempt %d/%d)",
+                       url, resp.status_code, delay, attempt, _FETCH_MAX_ATTEMPTS)
+        time.sleep(delay)
+    assert last_resp is not None
+    last_resp.raise_for_status()
+    return last_resp.text  # unreachable; raise_for_status above raises
 
 
 def _flip_name(name: str) -> str:


### PR DESCRIPTION
## Summary
- Vercel's WAF fires a JS challenge for any datacenter IP (GH Actions, CF Workers, even CF Browser Run with real headless Chromium); plain HTTP can't solve it.
- Routed `fetch_html` in `crawl_euroleague.py` through ScrapingBee when `SCRAPINGBEE_API_KEY` is set; falls back to direct fetch (with retry/backoff) when the env var is unset, so local runs still work unchanged.
- Wired the secret into the workflow's Euroleague crawl step.
- ScrapingBee's free tier (1,000 credits/mo) at 1 credit per Euroleague page is far more than this trigger ever needs.

## Test plan
- [x] All 33 basketball unit tests still pass locally
- [x] Triggered the workflow end-to-end on this branch — full pipeline green: basket.co.il + Euroleague crawl + both upload steps
- [x] Confirmed the Euroleague page (`כדורסל:16-04-2026 מכבי תל אביב נגד וירטוס בולוניה - יורוליג`) was actually re-uploaded to MaccabiPedia
- [ ] After merge, `repository_dispatch: zapier_trigger_basketball_upload_game` should keep working (no behavior change on that path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)