### PR TITLE
docs(dev): add context window hygiene rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,18 @@ Any PR touching `packages/maccabistats/` must also include, before the PR is cre
 2. **Changelog entry** — prepend a new entry to `packages/maccabistats/CHANGELOG.md` with the new version and a short description
 3. **Commit both** on the feature branch (e.g. `bump: maccabistats 2.61`)
 
-## 6. Reference Files
+## 6. Context Window Hygiene
+
+Every tool call result stays in context forever. Keep all outputs small:
+
+- **Explore agents**: always instruct them to write findings to `.claude/tmp/explore_<topic>.md` and return only a 3–5 line summary. Never ask for "comprehensive" or "thorough" reports that return inline.
+- **Subagent results**: any Agent call should write its output to `.claude/tmp/` and return a brief summary — not the full analysis inline.
+- **Write vs Edit**: never use Write to modify an existing file — Edit sends only the diff. Only use Write for new files, and avoid writing files larger than ~100 lines in one shot; break them up.
+- **Bash outputs**: if a script produces more than ~50 lines, redirect verbose output to a temp file and print only the final result.
+- **Trello MCP**: never call `get_cards_by_list_id` — it returns full JSON for every card (~40K chars). Use `get_card` on specific card IDs only.
+- **Knowledge files** (`.claude/*.md`): never Read the whole file. Use Grep to find the relevant section, then Read only those lines.
+
+## 7. Reference Files
 - `.claude/maccabipedia_structure_knowledge.md` — Game pages, player pages, templates, Cargo API
 - `.claude/maccabipedia_research_sources.md` — External data sources: rosters, match results, historical records, photos, video
 - `.claude/maccabistats_knowledge.md` — maccabistats Python package API reference


### PR DESCRIPTION
## Summary
- Add CLAUDE.md section 6 "Context Window Hygiene" with 6 rules derived from analyzing actual session JSONL data
- Rules target the real top token consumers: subagent results returned inline, large Write calls, Trello `get_cards_by_list_id`, and reading knowledge files in full

## What changed and why
Investigated token usage across all worktree sessions. Top findings:
- Explore/review subagent results were being returned inline (15–32K chars each)
- `get_cards_by_list_id` returns full board JSON (~40K chars per call)
- Write tool on large files embeds full content permanently in context
- Knowledge files read in full (~15K chars) when only a section was needed

## Test plan
- [ ] No code changes — docs only
- [ ] Rules are derived from real data in `.claude/tmp/analyze_*.py` scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)