### PR TITLE
chore(ci): switch Tailscale auth to OAuth client

### DIFF
--- a/.github/workflows/basketball_games_uploader.yaml
+++ b/.github/workflows/basketball_games_uploader.yaml
@@ -34,7 +34,9 @@ jobs:
       - name: Connect to Tailscale
         uses: tailscale/github-action@v3
         with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:ci
 
       - name: Crawl Euroleague (via residential proxy)
         env:


### PR DESCRIPTION
Replace expiring authkey with OAuth client — no key rotation needed.