### PR TITLE
fix(ci): remove invalid tag:ci from Tailscale OAuth action

### DIFF
--- a/.github/workflows/basketball_games_uploader.yaml
+++ b/.github/workflows/basketball_games_uploader.yaml
@@ -36,7 +36,6 @@ jobs:
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
-          tags: tag:ci
 
       - name: Crawl Euroleague (via residential proxy)
         env:


### PR DESCRIPTION
## Summary
- Removes `tags: tag:ci` from the Tailscale GitHub Action in `basketball_games_uploader.yaml`
- This tag doesn't exist in the Tailscale ACL, causing a 400 error and workflow failure
- The OAuth client already has its own permissions; no tag override is needed

## Test plan
- [ ] Trigger `basketball_games_uploader` workflow and verify Tailscale connects successfully