### PR TITLE
ci: run upload-game workflows on cron schedule (1pm/6pm/midnight IDT)

### DIFF
--- a/.github/workflows/basketball_games_uploader.yaml
+++ b/.github/workflows/basketball_games_uploader.yaml
@@ -1,5 +1,7 @@
 name: Upload Basketball Games To MaccabiPedia
 on:
+  schedule:
+    - cron: '0 10,15,21 * * *'  # 1pm, 6pm, midnight IDT (UTC+3)
   workflow_dispatch:
   repository_dispatch:
     types: [zapier_trigger_basketball_upload_game]

--- a/.github/workflows/basketball_games_uploader.yaml
+++ b/.github/workflows/basketball_games_uploader.yaml
@@ -36,7 +36,6 @@ jobs:
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
-          tags: tag:ci
 
       - name: Crawl Euroleague (via residential proxy)
         env:

--- a/.github/workflows/basketball_games_uploader.yaml
+++ b/.github/workflows/basketball_games_uploader.yaml
@@ -38,6 +38,7 @@ jobs:
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:ci
 
       - name: Crawl Euroleague (via residential proxy)
         env:

--- a/.github/workflows/upload_last_game_to_maccabipedia.yaml
+++ b/.github/workflows/upload_last_game_to_maccabipedia.yaml
@@ -1,5 +1,7 @@
 name: Upload Last Game To MaccabiPedia
 on:
+  schedule:
+    - cron: '0 10,15,21 * * *'  # 1pm, 6pm, midnight IDT (UTC+3)
   workflow_dispatch:
   repository_dispatch:
     types: [ zapier_trigger ]

--- a/.github/workflows/upload_volleyball_games.yaml
+++ b/.github/workflows/upload_volleyball_games.yaml
@@ -1,5 +1,7 @@
 name: Upload Volleyball Games To MaccabiPedia
 on:
+  schedule:
+    - cron: '0 10,15,21 * * *'  # 1pm, 6pm, midnight IDT (UTC+3)
   workflow_dispatch:
   repository_dispatch:
     types: [ zapier_trigger_volleyball_upload_game ]


### PR DESCRIPTION
## Summary
- Adds a `schedule` trigger to all three upload-game workflows (football, volleyball, basketball)
- Runs at `0 10,15,21 * * *` UTC = 1pm, 6pm, midnight IDT (UTC+3); 1 hour off in winter (IST)
- Existing `workflow_dispatch` and Zapier `repository_dispatch` triggers are unchanged

## Test Plan
- [ ] Verify all three workflows appear in GitHub Actions scheduled runs after merge
- [ ] Confirm no duplicate game pages are created on the next scheduled run