### PR TITLE
fix(football): resolve AnyStr NameError that crashed upload-last-game workflow

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/football/gamesbot.py
+++ b/packages/maccabipediabot/src/maccabipediabot/football/gamesbot.py
@@ -267,7 +267,7 @@ def create_or_update_game_page(game, overwrite_existing_pages: bool = True) -> b
     return True
 
 
-def get_games_that_has_existing_pages(games: List[AnyStr]):
+def get_games_that_has_existing_pages(games: List[str]):
     existing_games = []
     existing_games_pages = get_all_football_games_category_pages()
     for game_page in existing_games_pages:

--- a/packages/maccabipediabot/tests/conftest.py
+++ b/packages/maccabipediabot/tests/conftest.py
@@ -15,3 +15,10 @@ os.environ.setdefault("MACCABIPEDIA_VOLLEYBALL_ROOT", "/tmp/mp-volleyball")
 os.environ.setdefault("MACCABIPEDIA_BASKETBALL_TICKETS_ROOT", "/tmp/mp-basketball-tickets")
 os.environ.setdefault("MACCABIPEDIA_PAPERS_ROOT", "/tmp/mp-papers")
 os.environ.setdefault("YOUTUBE_API_KEY", "stub-youtube-key")
+
+# maintenance/football/league_tables_files_to_game_pages.py calls
+# load_from_maccabipedia_source() at module scope, which expects a serialized
+# games file on disk that doesn't exist in CI. Stub it.
+import maccabistats  # noqa: E402
+
+maccabistats.load_from_maccabipedia_source = lambda: MagicMock(name="stub-games")

--- a/packages/maccabipediabot/tests/conftest.py
+++ b/packages/maccabipediabot/tests/conftest.py
@@ -1,2 +1,17 @@
 # maccabipediabot is installed as a uv workspace member (uv sync)
 # No sys.path manipulation needed.
+import os
+from unittest.mock import MagicMock
+
+# Modules like football/gamesbot.py call get_site() at module scope; stub it so
+# test collection doesn't require real wiki credentials.
+from maccabipediabot.common import wiki_login
+
+wiki_login.get_site = lambda: MagicMock(name="stub-site")
+
+# Modules that raise at import time if env vars are missing (per the
+# no-hardcoded-paths convention). Dummy values let smoke tests import them.
+os.environ.setdefault("MACCABIPEDIA_VOLLEYBALL_ROOT", "/tmp/mp-volleyball")
+os.environ.setdefault("MACCABIPEDIA_BASKETBALL_TICKETS_ROOT", "/tmp/mp-basketball-tickets")
+os.environ.setdefault("MACCABIPEDIA_PAPERS_ROOT", "/tmp/mp-papers")
+os.environ.setdefault("YOUTUBE_API_KEY", "stub-youtube-key")

--- a/packages/maccabipediabot/tests/test_import_smoke.py
+++ b/packages/maccabipediabot/tests/test_import_smoke.py
@@ -1,0 +1,38 @@
+"""Every submodule under maccabipediabot must import cleanly.
+
+Catches module-scope NameError / ImportError / SyntaxError that would
+otherwise only surface at CI runtime (see PR that added this file).
+"""
+import importlib
+import pkgutil
+
+import pytest
+
+import maccabipediabot
+
+
+# Pywikibot config files (user-config.py, user-password.py) live inside the
+# package for deployment, but they're executed by pywikibot in a prepared
+# namespace — importing them directly raises NameError on undefined vars.
+_EXCLUDED_PREFIXES = ("maccabipediabot.pywikibot_configs",)
+
+# Missing optional dep (openpyxl); tracked separately, excluded from smoke.
+_EXCLUDED_MODULES = {
+    "maccabipediabot.maintenance.videos.extract_links",
+}
+
+
+def _all_submodules() -> list[str]:
+    return [
+        info.name
+        for info in pkgutil.walk_packages(
+            maccabipediabot.__path__, prefix="maccabipediabot."
+        )
+        if not info.name.startswith(_EXCLUDED_PREFIXES)
+        and info.name not in _EXCLUDED_MODULES
+    ]
+
+
+@pytest.mark.parametrize("module_name", _all_submodules())
+def test_module_imports(module_name: str) -> None:
+    importlib.import_module(module_name)


### PR DESCRIPTION
## Summary
- Fix `NameError: name 'AnyStr' is not defined` in `football/gamesbot.py:270` that crashed the **Upload Last Game To MaccabiPedia** workflow ([run 24638674126](https://github.com/Maccabipedia/maccabipedia/actions/runs/24638674126)). The function was annotated `List[AnyStr]` but `AnyStr` was never imported — fixed by using `List[str]`.
- Add a parametrized import smoke test that walks every submodule under `maccabipediabot.*` (81 modules) and asserts it imports cleanly. Confirmed to catch the exact `NameError` above when the fix is reverted.
- `conftest.py` now stubs `get_site` and sets dummy env vars so modules doing eager login / env-var checks at module scope can be smoke-tested without credentials.

## Test plan
- [x] `uv run pytest` — 462 passed
- [x] Spot-check: reverting only the `AnyStr` fix makes `test_module_imports[maccabipediabot.football.gamesbot]` fail with the same `NameError` CI hit
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)