### PR TITLE
fix: stop resolving env-backed values at module import time

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/football/videos/notify_broken_youtube_videos.py
+++ b/packages/maccabipediabot/src/maccabipediabot/football/videos/notify_broken_youtube_videos.py
@@ -14,8 +14,6 @@ import logging
 from maccabipediabot.common.logging_setup import setup_logging
 setup_logging(level=logging.INFO)
 
-_API = os.environ['YOUTUBE_API_KEY']
-
 
 def youtube_link(link):
     return 'youtube.' in link or 'youtu.be' in link
@@ -31,7 +29,8 @@ def youtube_video_active_and_public(link):
     else:
         raise Exception("Not a familiar youtube format")
 
-    query_youtube_video_api = f'https://www.googleapis.com/youtube/v3/videos?id={youtube_id}&key={_API}&part=status'
+    api_key = os.environ['YOUTUBE_API_KEY']
+    query_youtube_video_api = f'https://www.googleapis.com/youtube/v3/videos?id={youtube_id}&key={api_key}&part=status'
     answer = requests.get(query_youtube_video_api)
     if answer.status_code != 200:
         raise Exception(f"Bad answer from youtube api, code: {answer.status_code}, json: {answer.json()}")

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/basketball/upload_basketball_tickets.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/basketball/upload_basketball_tickets.py
@@ -18,7 +18,7 @@ Dependencies:
     pywikibot, requests
 
 Configuration:
-    Set TICKETS_BASE_FOLDER to the batch folder containing the 'input' sub-folder.
+    Set MACCABIPEDIA_BASKETBALL_TICKETS_ROOT to the batch folder containing the 'input' sub-folder.
     Set SHOULD_SAVE = False to do a dry-run without uploading.
 """
 
@@ -30,6 +30,7 @@ from datetime import datetime
 import contextlib
 
 from maccabipediabot.common.logging_setup import setup_logging
+from maccabipediabot.common.paths import basketball_tickets_root
 from maccabipediabot.common.wiki_login import get_site
 import pywikibot as pw
 from pywikibot.comms import http as pw_http
@@ -42,9 +43,6 @@ site = get_site()
 
 API_URL = 'https://www.maccabipedia.co.il/api.php'
 
-# Configuration
-from maccabipediabot.common.paths import basketball_tickets_root
-TICKETS_BASE_FOLDER = basketball_tickets_root()
 SHOULD_SAVE = True
 
 TEMPLATE_NAME = "תיוג כרטיס משחק כדורסל"
@@ -54,19 +52,19 @@ SUPPORTED_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.pdf'}
 
 
 def _input_folder() -> Path:
-    return TICKETS_BASE_FOLDER / 'input'
+    return basketball_tickets_root() / 'input'
 
 
 def _passed_folder() -> Path:
-    return TICKETS_BASE_FOLDER / 'passed'
+    return basketball_tickets_root() / 'passed'
 
 
 def _failed_folder() -> Path:
-    return TICKETS_BASE_FOLDER / 'failed'
+    return basketball_tickets_root() / 'failed'
 
 
 def _duplicate_folder() -> Path:
-    return TICKETS_BASE_FOLDER / 'duplicate'
+    return basketball_tickets_root() / 'duplicate'
 
 
 def _ensure_folders_exist() -> None:

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/papers/try_fix_papers_names.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/papers/try_fix_papers_names.py
@@ -2,12 +2,11 @@ import logging
 from pathlib import Path
 
 from maccabipediabot.common.logging_setup import setup_logging
+from maccabipediabot.common.paths import papers_root
 
 setup_logging(level=logging.INFO)
 
 _PAPER_NAME = "למרחב"
-from maccabipediabot.common.paths import papers_root
-BASE_PAPER_FOLDER_PATH = papers_root() / 'למרחב' / 'למרחב 70-71'
 
 
 def rename_file(old_file: Path, new_file: Path, reason: str = "") -> Path:
@@ -85,7 +84,7 @@ def show_papers_names(base_folder: Path) -> None:
 
 
 if __name__ == '__main__':
-    folder = BASE_PAPER_FOLDER_PATH
+    folder = papers_root() / 'למרחב' / 'למרחב 70-71'
 
     for current_paper in folder.iterdir():
         if not current_paper.is_file():

--- a/packages/maccabipediabot/src/maccabipediabot/volleyball/gamesbot_volleyball.py
+++ b/packages/maccabipediabot/src/maccabipediabot/volleyball/gamesbot_volleyball.py
@@ -19,7 +19,6 @@ site = get_site()
 
 setup_logging(level=logging.INFO)
 
-VOLLEYBALL_ROOT_FOLDER = volleyball_root()
 ALLOWED_SEASONS = ['1999-00']
 
 volleyball_games_prefix = "כדורעף"
@@ -69,7 +68,7 @@ FILES_TO_IGNORE = {'desktop.ini'}
 
 def build_volleyball_game_from_folder(potential_game_folder: Path) -> VolleyballGame:
     raw_season, raw_competition, raw_game_details = potential_game_folder.relative_to(
-        VOLLEYBALL_ROOT_FOLDER).parts
+        volleyball_root()).parts
 
     season = raw_season.replace("עונת", "").strip().replace("-", "/")
     competition = raw_competition
@@ -101,8 +100,9 @@ def build_volleyball_game_from_folder(potential_game_folder: Path) -> Volleyball
 def get_volleyball_games() -> List[VolleyballGame]:
     all_games = []
 
-    for potential_game_folder in VOLLEYBALL_ROOT_FOLDER.glob("**"):
-        if len(potential_game_folder.relative_to(VOLLEYBALL_ROOT_FOLDER).parts) != 3:
+    root = volleyball_root()
+    for potential_game_folder in root.glob("**"):
+        if len(potential_game_folder.relative_to(root).parts) != 3:
             logging.info(f'skipping folder: {potential_game_folder}, this folder has less parts than needed')
             continue
 

--- a/packages/maccabipediabot/tests/conftest.py
+++ b/packages/maccabipediabot/tests/conftest.py
@@ -1,6 +1,5 @@
 # maccabipediabot is installed as a uv workspace member (uv sync)
 # No sys.path manipulation needed.
-import os
 from unittest.mock import MagicMock
 
 # Modules like football/gamesbot.py call get_site() at module scope; stub it so
@@ -8,13 +7,6 @@ from unittest.mock import MagicMock
 from maccabipediabot.common import wiki_login
 
 wiki_login.get_site = lambda: MagicMock(name="stub-site")
-
-# Modules that raise at import time if env vars are missing (per the
-# no-hardcoded-paths convention). Dummy values let smoke tests import them.
-os.environ.setdefault("MACCABIPEDIA_VOLLEYBALL_ROOT", "/tmp/mp-volleyball")
-os.environ.setdefault("MACCABIPEDIA_BASKETBALL_TICKETS_ROOT", "/tmp/mp-basketball-tickets")
-os.environ.setdefault("MACCABIPEDIA_PAPERS_ROOT", "/tmp/mp-papers")
-os.environ.setdefault("YOUTUBE_API_KEY", "stub-youtube-key")
 
 # maintenance/football/league_tables_files_to_game_pages.py calls
 # load_from_maccabipedia_source() at module scope, which expects a serialized


### PR DESCRIPTION
## Summary

The volleyball calendar workflow has been failing on import (run [24638533920](https://github.com/Maccabipedia/maccabipedia/actions/runs/24638533920/job/72038246219)). Root cause: `gamesbot_volleyball.py` called `volleyball_root()` at module top, which raises after 6654a8e made env vars required. The calendar doesn't set `MACCABIPEDIA_VOLLEYBALL_ROOT` (it doesn't touch the filesystem), so the import crashed.

While here, fix every remaining instance of the same pattern so PR #105's `test_import_smoke.py` can natively guard the rule going forward.

## Changes

- `volleyball/gamesbot_volleyball.py`: lazy `volleyball_root()` (the workflow-breaking one).
- `maintenance/basketball/upload_basketball_tickets.py`: lazy `basketball_tickets_root()`.
- `maintenance/papers/try_fix_papers_names.py`: lazy `papers_root()` (only used in `__main__`).
- `football/videos/notify_broken_youtube_videos.py`: lazy `os.environ['YOUTUBE_API_KEY']`.
- `tests/conftest.py`: drop the four `os.environ.setdefault` stubs that PR #105 added to silence the eager calls. With imports lazy, the stubs are dead — and worse, they masked future regressions (any new eager call would import-test green here while breaking the cron that doesn't set the var). Without them, `test_import_smoke.py` catches the bug class natively.

## Test plan

- [x] `uv run pytest` — 462 passed, including `test_import_smoke.py` for every submodule with no env-var stubs.
- [x] mypy — no new errors.
- [ ] After merge, watch the next scheduled run of `update_maccabipedia_volleyball_calendar` to confirm it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)