### PR TITLE
fix(maccabistats): retry Cargo Export on transient 415/5xx

### DIFF
--- a/packages/maccabistats/CHANGELOG.md
+++ b/packages/maccabistats/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 2.66 ##
+
+    Retry MaccabiPedia Cargo Export requests on transient 5xx/4xx (415, 429, 500-504) via
+    a requests.Session with urllib3.Retry, so daily jobs survive the brief openresty blips
+    that take the site off-nginx (CI runs 24473693887 and 24685264058).
+
 ## Version 2.65 ##
 
     Retry maccabi-tlv.co.il game page fetches on transient 5xx errors via a

--- a/packages/maccabistats/src/maccabistats/parse/maccabipedia/maccabipedia_cargo_chunks_crawler.py
+++ b/packages/maccabistats/src/maccabistats/parse/maccabipedia/maccabipedia_cargo_chunks_crawler.py
@@ -6,12 +6,34 @@ from typing import Dict
 import html
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
 from maccabistats.config import MaccabiStatsConfigSingleton
 
 logger = logging.getLogger(__name__)
 
 _MAX_LIMIT_PER_REQUEST = 5000  # mediawiki api hardcoded limit
 _MUST_HAVE_FIELDS = "_pageName"
+
+# MaccabiPedia occasionally serves transient 415 from an openresty proxy (normal server is nginx);
+# seen twice in six days at ~19:00 UTC. Retry across those blips instead of failing the daily job.
+_RETRYABLE_STATUSES = (408, 415, 429, 500, 502, 503, 504)
+
+
+def _build_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=5,
+        backoff_factor=2,
+        status_forcelist=_RETRYABLE_STATUSES,
+        allowed_methods=frozenset(["GET"]),
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
 
 
 class MaccabiPediaCargoChunksCrawler(Iterator):
@@ -39,6 +61,7 @@ class MaccabiPediaCargoChunksCrawler(Iterator):
         self._current_offset = 0
         self._finished_to_crawl = False
         self._already_fetched_data_queue = deque()
+        self._session = _build_session()
 
     @property
     def full_crawl_address(self):
@@ -60,7 +83,7 @@ class MaccabiPediaCargoChunksCrawler(Iterator):
         """
 
         # Get data
-        request_result = requests.get(self.full_crawl_address)
+        request_result = self._session.get(self.full_crawl_address, timeout=30)
         if request_result.status_code != 200:
             logging.exception(f"Error while fetching data from address: {self.full_crawl_address}, "
                               f"status code: {request_result.status_code}, text: {request_result.text}")

--- a/packages/maccabistats/src/maccabistats/version.py
+++ b/packages/maccabistats/src/maccabistats/version.py
@@ -1,1 +1,1 @@
-version = "2.65"
+version = "2.66"


### PR DESCRIPTION
## Summary
- `Find MaccabiPedia Errors` has failed twice in six days with the exact same signature: HTTP **415** from `Server: openresty/1.27.1.1`, while healthy responses come from `Server: nginx` — a brief edge-proxy blip around ~19:00 UTC (runs [24685264058](https://github.com/Maccabipedia/maccabipedia/actions/runs/24685264058) and [24473693887](https://github.com/Maccabipedia/maccabipedia/actions/runs/24473693887)).
- The cargo chunks crawler used a bare `requests.get` with no retry, so one blip killed the daily job.
- Fix: switch to a `requests.Session` + `urllib3.Retry` (5 attempts, `backoff_factor=2`, `status_forcelist=(408, 415, 429, 500, 502, 503, 504)`) with a 30s timeout. Same shape as #107's maccabi-tlv fix.
- Bumps `maccabistats` → 2.66 with a changelog entry.

## Test plan
- [x] `uv run pytest packages/maccabistats` — 234 passed
- [x] Live probe through the new `_build_session()` hits the real Cargo Export URL: 200, `application/json`, ~5 MB
- [x] Exact failing URL hit 5× in a row manually — all 200 from `nginx` (endpoint currently healthy)
- [ ] Daily scheduled run at ~19:00 UTC rides through the next openresty blip instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)