### PR TITLE
feat(maintenance): YouTube backup uploader for deleted football videos

### DIFF
--- a/.claude/maccabipedia_youtube_channel.md
+++ b/.claude/maccabipedia_youtube_channel.md
@@ -1,0 +1,92 @@
+# MaccabiPedia YouTube Channel
+
+Our channel — used to host Maccabi Tel Aviv match videos referenced from the wiki. When a match video gets deleted from an external channel, we upload our local backup here and update the wiki.
+
+Channel: https://www.youtube.com/@MaccabiPedia
+
+## Video Metadata Conventions
+
+- **Titles:** `עונת [YEAR] [COMPETITION] [ROUND] מכבי תל אביב - [OPPONENT] ([OPPONENT_SCORE]-[MACCABI_SCORE]) [TYPE]`
+  - Score is in parentheses at the end, digits **stored reversed** (opponent's goals first). YouTube's BIDI renderer flips digit order inside parens in RTL context, so storing `(2-0)` displays as `(0-2)` — and Hebrew readers interpret `Maccabi - Hapoel (0-2)` as Maccabi=0, Hapoel=2, which is the intended semantics.
+  - TYPE: `משחק מלא` for full match, `תקציר` for highlights
+  - Example: `עונת 2008-09 גביע המדינה סיבוב ט מכבי תל אביב - הפועל תל אביב (2-0) תקציר` (Maccabi lost 0-2; displayed as `(0-2)`)
+  - Competition: use the name from the wiki page (`ליגת העל`, `ליגה לאומית`, `גביע המדינה`, `גביע הטוטו`, `ליגת האלופות`, `ליגה האירופאית`, `גביע אירופה למחזיקות גביע`)
+- **Description:** the wiki game-page URL, **URL-encoded** so YouTube auto-linkifies it (YouTube's linkifier is unreliable with non-ASCII URLs). Example: `https://www.maccabipedia.co.il/%D7%9E%D7%A9%D7%97%D7%A7:...`
+- **Tags:** empty
+- **Category:** Sports (ID 17)
+- **Privacy:** public
+
+## Playlists
+
+One playlist per season: `מכביפדיה | עונת YYYY/YY` (e.g. `מכביפדיה | עונת 2001/02`).
+Also: `מכביפדיה | דיסק פנאטיקס`.
+
+**Every uploaded video is added to its season playlist.** If a season playlist doesn't exist yet, create it (public) before adding the video.
+
+## Google Drive Video Backup Structure
+
+All paths below are relative to `/mnt/d/maccabipedia_google_drive/מכביפדיה_ראשי/וידאו/`
+
+### Football (כדורגל)
+```
+כדורגל/עונות/עונת [YEAR]/[COMPETITION]/[ROUND]/[תקציר|משחק מלא]/[filename]
+```
+
+Domestic competitions (Hebrew names, Hebrew filenames):
+- `ליגה לאומית/מחזור [N]/תקציר|משחק מלא/`
+- `גביע המדינה/סיבוב [X]/תקציר|משחק מלא/` (also `שמינית גמר`, `רבע גמר`, `חצי גמר`, `גמר`)
+- `גביע הטוטו/מחזור [N]/תקציר|משחק מלא/`
+
+European competitions (English round names, English filenames):
+- `Europa League/[Round]/[Team1 Score-Score Team2]/Full Match|Highlights/`
+- `Champions League/[Round]/[Team1 Score-Score Team2]/Full Match|Highlights/`
+- `Cup Winner's Cup/[Round]/[Team1 Score-Score Team2]/Full Match|Highlights/`
+
+Note: folders for pre-1999 seasons say `ליגה לאומית`, but on YouTube/wiki the competition is `ליגת העל` post-1999.
+
+### Basketball (כדורסל)
+```
+כדורסל/[YEAR]/[competition]/
+```
+Only `2000-01/suproleague/` confirmed so far.
+
+### Volleyball (כדורעף)
+Files directly under `כדורעף/` named `כדורעף - [DD-MM-YYYY] [teams] - [competition]`
+
+Formats found: `.webm`, `.mp4`, `.m4v`, `.mkv`, `.flv`
+
+## OAuth Credentials
+
+- Client secret: `~/.config/maccabipedia/youtube_client_secret.json`
+- Token (reusable): `~/.config/maccabipedia/youtube_token.json`
+- Scopes: `youtube.upload` + `youtube` (the second is needed to create playlists and add items to them)
+- Auth script: `.claude/scripts/youtube_auth.py`
+
+**IMPORTANT:** @MaccabiPedia is a **Google Brand Account**. During OAuth sign-in, the correct Google account (the one that manages the MaccabiPedia brand) must be selected. Authenticating with the wrong account gives a token with `channels().list(mine=True)` returning 0 items, and playlist/upload calls fail with "Channel not found".
+
+**Token expiry:** The OAuth app is in "Testing" mode in Google Cloud → refresh tokens expire after **7 days**. Publishing the app in OAuth consent screen removes the expiry (no Google verification is needed for private use).
+
+## Upload Script
+
+`.claude/scripts/youtube_upload.py` — arguments:
+- `--file`: path to the video file
+- `--title`: YouTube title (follow the convention above)
+- `--playlist`: playlist title (e.g. `מכביפדיה | עונת 2001/02`); created if missing
+
+Run with `uv run python .claude/scripts/youtube_upload.py --file ... --title ... --playlist ...`. The script uploads, prints the resulting video URL, and adds it to the playlist.
+
+## API Quota
+
+YouTube Data API default quota: **10,000 units/day**. Each upload costs 1,600 units, and a playlist insert/add costs 50 — so ~6 uploads per day max before the quota resets.
+
+## Useful Commands (no API key needed)
+
+List recent videos:
+```
+yt-dlp --flat-playlist --print "%(title)s | %(id)s" "https://www.youtube.com/@MaccabiPedia/videos"
+```
+
+List all playlists (title + ID):
+```
+yt-dlp --flat-playlist --print "%(title)s | %(id)s" "https://www.youtube.com/@MaccabiPedia/playlists"
+```

--- a/.claude/maccabipedia_youtube_channel.md
+++ b/.claude/maccabipedia_youtube_channel.md
@@ -1,6 +1,8 @@
 # MaccabiPedia YouTube Channel
 
-Our channel — used to host Maccabi Tel Aviv match videos referenced from the wiki. When a match video gets deleted from an external channel, we upload our local backup here and update the wiki.
+Our channel — used to host Maccabi Tel Aviv match videos referenced from the wiki. When a match video gets deleted from an external channel (see `find_broken_videos.py`), we upload our local backup here and update the wiki to point at the new URL.
+
+This doc captures the conventions that aren't obvious from the code: title format quirks (BIDI), brand-account OAuth gotchas, and the Google Drive backup folder layout. Keep it current when the upload workflow changes — the next operator will read it first.
 
 Channel: https://www.youtube.com/@MaccabiPedia
 

--- a/.claude/maccabipedia_youtube_channel.md
+++ b/.claude/maccabipedia_youtube_channel.md
@@ -4,7 +4,28 @@ Our channel — used to host Maccabi Tel Aviv match videos referenced from the w
 
 This doc captures the conventions that aren't obvious from the code: title format quirks (BIDI), brand-account OAuth gotchas, and the Google Drive backup folder layout. Keep it current when the upload workflow changes — the next operator will read it first.
 
-**Workflow:** see `CLAUDE.md` §5 "Restore a Deleted Football Video" for the step-by-step commands (`youtube.auth`, then `restore_deleted_football_video` with `--dry-run`, then the real run).
+## Restore-video workflow
+
+When `find_broken_videos` flags a broken YouTube link on a game page and a local backup exists under the MaccabiPedia Google Drive, re-host the backup here and relink the wiki:
+
+1. **One-time auth** (or once per week — Testing-mode tokens expire):
+   ```
+   uv run python -m maccabipediabot.maintenance.videos.youtube.auth
+   ```
+   Open the printed URL, sign in with the account that **manages the MaccabiPedia brand** on YouTube (a personal account is rejected by the token verifier).
+
+2. **Dry-run first** — previews the computed title / playlist / wiki field without uploading or editing:
+   ```
+   uv run python -m maccabipediabot.maintenance.videos.restore_deleted_football_video \
+     --file "$MACCABIPEDIA_GOOGLE_DRIVE_ROOT/…/<backup>.mp4" \
+     --wiki-page "משחק:DD-MM-YYYY …" \
+     --video-type highlights \
+     --dry-run
+   ```
+
+3. **Real run** — drop `--dry-run`. Uploads, adds to the season playlist (creates it if missing), then sets the `תקציר וידאו` or `משחק מלא` field on the wiki page.
+
+All game metadata (season, competition, stage, opponent, scores) is read from the wiki page; the three args above are the only ones you supply. Scope: football only.
 
 Channel: https://www.youtube.com/@MaccabiPedia
 

--- a/.claude/maccabipedia_youtube_channel.md
+++ b/.claude/maccabipedia_youtube_channel.md
@@ -19,13 +19,12 @@ Channel: https://www.youtube.com/@MaccabiPedia
 ## Playlists
 
 One playlist per season: `מכביפדיה | עונת YYYY/YY` (e.g. `מכביפדיה | עונת 2001/02`).
-Also: `מכביפדיה | דיסק פנאטיקס`.
 
 **Every uploaded video is added to its season playlist.** If a season playlist doesn't exist yet, create it (public) before adding the video.
 
 ## Google Drive Video Backup Structure
 
-All paths below are relative to `/mnt/d/maccabipedia_google_drive/מכביפדיה_ראשי/וידאו/`
+All paths below are relative to `$MACCABIPEDIA_GOOGLE_DRIVE_ROOT/מכביפדיה_ראשי/וידאו/` (the mapped drive root — `/mnt/d/maccabipedia_google_drive` on Roee's WSL machine, but operator-specific).
 
 ### Football (כדורגל)
 ```

--- a/.claude/maccabipedia_youtube_channel.md
+++ b/.claude/maccabipedia_youtube_channel.md
@@ -4,6 +4,8 @@ Our channel — used to host Maccabi Tel Aviv match videos referenced from the w
 
 This doc captures the conventions that aren't obvious from the code: title format quirks (BIDI), brand-account OAuth gotchas, and the Google Drive backup folder layout. Keep it current when the upload workflow changes — the next operator will read it first.
 
+**Workflow:** see `CLAUDE.md` §5 "Restore a Deleted Football Video" for the step-by-step commands (`youtube.auth`, then `restore_deleted_football_video` with `--dry-run`, then the real run).
+
 Channel: https://www.youtube.com/@MaccabiPedia
 
 ## Video Metadata Conventions

--- a/.claude/maccabipedia_youtube_channel.md
+++ b/.claude/maccabipedia_youtube_channel.md
@@ -26,7 +26,7 @@ One playlist per season: `מכביפדיה | עונת YYYY/YY` (e.g. `מכביפ
 
 ## Google Drive Video Backup Structure
 
-All paths below are relative to `$MACCABIPEDIA_GOOGLE_DRIVE_ROOT/מכביפדיה_ראשי/וידאו/` (the mapped drive root — `/mnt/d/maccabipedia_google_drive` on Roee's WSL machine, but operator-specific).
+All paths below are relative to `$MACCABIPEDIA_GOOGLE_DRIVE_ROOT/מכביפדיה_ראשי/וידאו/`.
 
 ### Football (כדורגל)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,29 @@ Produces malformed HTTP (bad MIME headers, LF-only line endings) → Apache 400.
 - Monitor CI — if checks fail, fix and push before notifying the user
 - User reviews and merges
 
+### Restore a Deleted Football Video
+
+When `find_broken_videos` flags a broken YouTube link on a game page and a local backup exists under the MaccabiPedia Google Drive, re-host the backup on the MaccabiPedia YouTube channel and relink the wiki:
+
+1. **One-time auth** (or once per week, Testing-mode tokens expire):
+   ```
+   uv run python -m maccabipediabot.maintenance.videos.youtube.auth
+   ```
+   Open the printed URL, sign in with the account that manages the **MaccabiPedia brand** on YouTube (not a personal account — the token verifier will refuse a personal-account token).
+
+2. **Dry-run first** to preview title / playlist / wiki field without uploading:
+   ```
+   uv run python -m maccabipediabot.maintenance.videos.restore_deleted_football_video \
+     --file "$MACCABIPEDIA_GOOGLE_DRIVE_ROOT/…/<backup>.mp4" \
+     --wiki-page "משחק:DD-MM-YYYY …" \
+     --video-type highlights \
+     --dry-run
+   ```
+
+3. **Actual run** — drop `--dry-run`. Uploads, adds to the season playlist (creates it if missing), then sets the `תקציר וידאו` or `משחק מלא` field on the wiki page.
+
+All game metadata (season, competition, stage, opponent, scores) is read from the wiki page; the three args above are the only ones you supply. Scope: football only. See `.claude/maccabipedia_youtube_channel.md` for title conventions and the backup-folder layout.
+
 ### maccabistats Version Bump (maccabistats PRs only)
 
 Any PR touching `packages/maccabistats/` must also include, before the PR is created:
@@ -85,3 +108,4 @@ Every tool call result stays in context forever. Keep all outputs small:
 - `.claude/maccabipedia_structure_knowledge.md` — Game pages, player pages, templates, Cargo API
 - `.claude/maccabipedia_research_sources.md` — External data sources: rosters, match results, historical records, photos, video
 - `.claude/maccabistats_knowledge.md` — maccabistats Python package API reference
+- `.claude/maccabipedia_youtube_channel.md` — MaccabiPedia YouTube channel conventions + Google Drive backup layout (used by `restore_deleted_football_video`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,29 +60,6 @@ Produces malformed HTTP (bad MIME headers, LF-only line endings) → Apache 400.
 - Monitor CI — if checks fail, fix and push before notifying the user
 - User reviews and merges
 
-### Restore a Deleted Football Video
-
-When `find_broken_videos` flags a broken YouTube link on a game page and a local backup exists under the MaccabiPedia Google Drive, re-host the backup on the MaccabiPedia YouTube channel and relink the wiki:
-
-1. **One-time auth** (or once per week, Testing-mode tokens expire):
-   ```
-   uv run python -m maccabipediabot.maintenance.videos.youtube.auth
-   ```
-   Open the printed URL, sign in with the account that manages the **MaccabiPedia brand** on YouTube (not a personal account — the token verifier will refuse a personal-account token).
-
-2. **Dry-run first** to preview title / playlist / wiki field without uploading:
-   ```
-   uv run python -m maccabipediabot.maintenance.videos.restore_deleted_football_video \
-     --file "$MACCABIPEDIA_GOOGLE_DRIVE_ROOT/…/<backup>.mp4" \
-     --wiki-page "משחק:DD-MM-YYYY …" \
-     --video-type highlights \
-     --dry-run
-   ```
-
-3. **Actual run** — drop `--dry-run`. Uploads, adds to the season playlist (creates it if missing), then sets the `תקציר וידאו` or `משחק מלא` field on the wiki page.
-
-All game metadata (season, competition, stage, opponent, scores) is read from the wiki page; the three args above are the only ones you supply. Scope: football only. See `.claude/maccabipedia_youtube_channel.md` for title conventions and the backup-folder layout.
-
 ### maccabistats Version Bump (maccabistats PRs only)
 
 Any PR touching `packages/maccabistats/` must also include, before the PR is created:

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/restore_deleted_football_video.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/restore_deleted_football_video.py
@@ -131,7 +131,14 @@ def restore(
     video_path: Path,
     wiki_page_title: str,
     video_type: VideoType,
+    dry_run: bool = False,
 ) -> str:
+    """Run the full restore pipeline.
+
+    When `dry_run=True`, fetches metadata, runs the pre-flight check, and prints the
+    YouTube title / playlist / wiki field it *would* produce — without uploading or
+    editing the wiki. Returns an empty string.
+    """
     if not video_path.is_file():
         raise FileNotFoundError(f"Backup video not found: {video_path}")
 
@@ -153,6 +160,15 @@ def restore(
     )
     description = wiki_page_url(wiki_page_title)
     playlist_title = season_playlist_title(metadata.season)
+
+    if dry_run:
+        logger.info("DRY RUN — would upload:")
+        logger.info("  file:        %s", video_path)
+        logger.info("  title:       %s", youtube_title)
+        logger.info("  playlist:    %s", playlist_title)
+        logger.info("  description: %s", description)
+        logger.info("  wiki field:  %s on %s", wiki_field, wiki_page_title)
+        return ""
 
     logger.info("Uploading %s as %r to %r", video_path, youtube_title, playlist_title)
     video_id = upload_and_add_to_playlist(video_path, youtube_title, playlist_title, description)
@@ -186,6 +202,11 @@ def main() -> None:
     parser.add_argument(
         "--video-type", required=True, choices=sorted(CLI_VIDEO_TYPE_TO_INTERNAL.keys()),
     )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Fetch metadata and print the computed YouTube title / playlist / wiki "
+             "field, but don't upload or edit the wiki. No quota cost.",
+    )
     args = parser.parse_args()
 
     setup_logging(level=logging.INFO)
@@ -195,8 +216,10 @@ def main() -> None:
         video_path=Path(args.file),
         wiki_page_title=args.wiki_page,
         video_type=CLI_VIDEO_TYPE_TO_INTERNAL[args.video_type],
+        dry_run=args.dry_run,
     )
-    logger.info("Done. https://www.youtube.com/watch?v=%s", video_id)
+    if video_id:
+        logger.info("Done. https://www.youtube.com/watch?v=%s", video_id)
 
 
 if __name__ == "__main__":

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/restore_deleted_football_video.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/restore_deleted_football_video.py
@@ -4,13 +4,16 @@
   2. Add the new video to its season playlist (creating the playlist if missing).
   3. Update the matching field on the wiki game page to point at the new URL.
 
+Game metadata (season, competition, stage, opponent, scores) is read directly from
+the wiki page template — the wiki is the single source of truth. The operator only
+supplies the backup file, the wiki page title, and the video type.
+
 Pre-flight: the target wiki field must be empty. If it's already filled we abort
 before touching YouTube (don't clobber a working link).
 
-If upload succeeds but the wiki step fails, the video ID is logged loudly so the
-operator can run `update_wiki_video_field` separately to finish the job. There is no
-rollback: YouTube uploads cost 1,600 quota units and the daily cap is 10,000, so
-re-uploading on every retry would burn through the quota fast.
+If upload succeeds but the wiki step fails, the video URL is logged loudly with the
+exact recovery command. There is no rollback: YouTube uploads cost 1,600 quota units
+and the daily cap is 10,000, so re-uploading on every retry would burn through fast.
 
 Scope: football only. Basketball/volleyball use different wiki templates and Cargo
 tables; a ball-sports variant can reuse the youtube/ helpers if needed.
@@ -18,6 +21,7 @@ tables; a ball-sports variant can reuse the youtube/ helpers if needed.
 import argparse
 import logging
 import urllib.parse
+from dataclasses import dataclass
 from pathlib import Path
 
 import mwparserfromhell as mw
@@ -51,9 +55,56 @@ CLI_VIDEO_TYPE_TO_INTERNAL: dict[str, VideoType] = {
 }
 
 
+@dataclass(frozen=True)
+class GameMetadata:
+    season: str  # normalized to "YYYY-YY" (dash form, matching channel title convention)
+    competition: str
+    stage: str
+    opponent: str
+    maccabi_score: int
+    opponent_score: int
+
+
 def wiki_page_url(wiki_page_title: str) -> str:
     """URL-encode the title so YouTube's auto-linkifier treats the description as clickable."""
     return "https://www.maccabipedia.co.il/" + urllib.parse.quote(wiki_page_title.replace(" ", "_"), safe=":")
+
+
+def _game_template(wikitext: str, page_title_hint: str) -> mw.nodes.Template:
+    parsed = mw.parse(wikitext)
+    templates = parsed.filter_templates(matches=lambda tmpl: tmpl.name.strip() == TEMPLATE_NAME)
+    if not templates:
+        raise LookupError(f"Template '{TEMPLATE_NAME}' not found on {page_title_hint}")
+    return templates[0]
+
+
+def parse_game_metadata(wikitext: str, page_title_hint: str = "") -> GameMetadata:
+    """Pure function: extract `GameMetadata` from the page's wikitext."""
+    tmpl = _game_template(wikitext, page_title_hint)
+
+    def required(field: str) -> str:
+        if not tmpl.has(field):
+            raise LookupError(f"Required field '{field}' missing on {page_title_hint}")
+        value = str(tmpl.get(field).value).strip()
+        if not value:
+            raise LookupError(f"Required field '{field}' is empty on {page_title_hint}")
+        return value
+
+    return GameMetadata(
+        season=required("עונה").replace("/", "-"),
+        competition=required("מפעל"),
+        stage=required("שלב במפעל"),
+        opponent=required("שם יריבה"),
+        maccabi_score=int(required("תוצאת משחק מכבי")),
+        opponent_score=int(required("תוצאת משחק יריבה")),
+    )
+
+
+def fetch_game_metadata(site: pw.Site, page_title: str) -> GameMetadata:
+    page = pw.Page(site, page_title)
+    if not page.exists():
+        raise LookupError(f"Wiki page not found: {page_title}")
+    return parse_game_metadata(page.text, page_title)
 
 
 def _check_wiki_field_empty(site: pw.Site, wiki_page_title: str, field: str) -> None:
@@ -65,11 +116,8 @@ def _check_wiki_field_empty(site: pw.Site, wiki_page_title: str, field: str) -> 
     page = pw.Page(site, wiki_page_title)
     if not page.exists():
         raise LookupError(f"Wiki page not found: {wiki_page_title}")
-    parsed = mw.parse(page.text)
-    templates = parsed.filter_templates(matches=lambda tmpl: tmpl.name.strip() == TEMPLATE_NAME)
-    if not templates:
-        raise LookupError(f"Template '{TEMPLATE_NAME}' not found on {wiki_page_title}")
-    existing = str(templates[0].get(field).value).strip() if templates[0].has(field) else ""
+    tmpl = _game_template(page.text, wiki_page_title)
+    existing = str(tmpl.get(field).value).strip() if tmpl.has(field) else ""
     if existing:
         raise ValueError(
             f"Wiki field '{field}' on {wiki_page_title} is already set to '{existing}'. "
@@ -81,12 +129,6 @@ def restore(
     *,
     video_path: Path,
     wiki_page_title: str,
-    season: str,
-    competition: str,
-    round_name: str,
-    opponent: str,
-    maccabi_score: int,
-    opponent_score: int,
     video_type: VideoType,
 ) -> str:
     if not video_path.is_file():
@@ -96,17 +138,20 @@ def restore(
     site = get_site()
     _check_wiki_field_empty(site, wiki_page_title, wiki_field)
 
+    metadata = fetch_game_metadata(site, wiki_page_title)
+    logger.info("Fetched metadata from wiki: %s", metadata)
+
     youtube_title = format_video_title(
-        season=season,
-        competition=competition,
-        round_name=round_name,
-        maccabi_score=maccabi_score,
-        opponent=opponent,
-        opponent_score=opponent_score,
+        season=metadata.season,
+        competition=metadata.competition,
+        round_name=metadata.stage,
+        maccabi_score=metadata.maccabi_score,
+        opponent=metadata.opponent,
+        opponent_score=metadata.opponent_score,
         video_type=video_type,
     )
     description = wiki_page_url(wiki_page_title)
-    playlist_title = season_playlist_title(season)
+    playlist_title = season_playlist_title(metadata.season)
 
     logger.info("Uploading %s as %r to %r", video_path, youtube_title, playlist_title)
     video_id = upload_and_add_to_playlist(video_path, youtube_title, playlist_title, description)
@@ -129,12 +174,6 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--file", required=True, help="Path to backup video file")
     parser.add_argument("--wiki-page", required=True, help="Full wiki page title (e.g. 'משחק:...')")
-    parser.add_argument("--season", required=True, help="Season in YYYY-YY form (e.g. 2008-09)")
-    parser.add_argument("--competition", required=True, help="Competition name as it appears on the wiki page")
-    parser.add_argument("--round", dest="round_name", required=True, help="Round name (e.g. 'מחזור 21', 'סיבוב ט')")
-    parser.add_argument("--opponent", required=True, help="Opponent team name")
-    parser.add_argument("--maccabi-score", type=int, required=True)
-    parser.add_argument("--opponent-score", type=int, required=True)
     parser.add_argument(
         "--video-type", required=True, choices=sorted(CLI_VIDEO_TYPE_TO_INTERNAL.keys()),
     )
@@ -146,12 +185,6 @@ def main() -> None:
     video_id = restore(
         video_path=Path(args.file),
         wiki_page_title=args.wiki_page,
-        season=args.season,
-        competition=args.competition,
-        round_name=args.round_name,
-        opponent=args.opponent,
-        maccabi_score=args.maccabi_score,
-        opponent_score=args.opponent_score,
         video_type=CLI_VIDEO_TYPE_TO_INTERNAL[args.video_type],
     )
     logger.info("Done. https://www.youtube.com/watch?v=%s", video_id)

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/restore_deleted_football_video.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/restore_deleted_football_video.py
@@ -1,0 +1,161 @@
+"""End-to-end restore of a deleted football video:
+
+  1. Upload the local backup to MaccabiPedia's YouTube channel.
+  2. Add the new video to its season playlist (creating the playlist if missing).
+  3. Update the matching field on the wiki game page to point at the new URL.
+
+Pre-flight: the target wiki field must be empty. If it's already filled we abort
+before touching YouTube (don't clobber a working link).
+
+If upload succeeds but the wiki step fails, the video ID is logged loudly so the
+operator can run `update_wiki_video_field` separately to finish the job. There is no
+rollback: YouTube uploads cost 1,600 quota units and the daily cap is 10,000, so
+re-uploading on every retry would burn through the quota fast.
+
+Scope: football only. Basketball/volleyball use different wiki templates and Cargo
+tables; a ball-sports variant can reuse the youtube/ helpers if needed.
+"""
+import argparse
+import logging
+import urllib.parse
+from pathlib import Path
+
+import mwparserfromhell as mw
+import pywikibot as pw
+
+from maccabipediabot.common.logging_setup import setup_logging
+from maccabipediabot.common.wiki_login import get_site
+from maccabipediabot.maintenance.videos.update_wiki_video_field import (
+    TEMPLATE_NAME,
+    set_video_field,
+)
+from maccabipediabot.maintenance.videos.youtube.title import (
+    FULL_MATCH,
+    HIGHLIGHTS,
+    VideoType,
+    format_video_title,
+    season_playlist_title,
+)
+from maccabipediabot.maintenance.videos.youtube.upload import upload_and_add_to_playlist
+
+logger = logging.getLogger(__name__)
+
+VIDEO_TYPE_TO_WIKI_FIELD: dict[VideoType, str] = {
+    FULL_MATCH: "משחק מלא",
+    HIGHLIGHTS: "תקציר וידאו",
+}
+
+CLI_VIDEO_TYPE_TO_INTERNAL: dict[str, VideoType] = {
+    "full-match": FULL_MATCH,
+    "highlights": HIGHLIGHTS,
+}
+
+
+def wiki_page_url(wiki_page_title: str) -> str:
+    """URL-encode the title so YouTube's auto-linkifier treats the description as clickable."""
+    return "https://www.maccabipedia.co.il/" + urllib.parse.quote(wiki_page_title.replace(" ", "_"), safe=":")
+
+
+def _check_wiki_field_empty(site: pw.Site, wiki_page_title: str, field: str) -> None:
+    """Abort if the target wiki field already has a value — we don't want to clobber it.
+
+    Race note: a concurrent edit between this check and `set_video_field`'s save can still
+    happen; set_video_field re-checks at save time and raises if the field became non-empty.
+    """
+    page = pw.Page(site, wiki_page_title)
+    if not page.exists():
+        raise LookupError(f"Wiki page not found: {wiki_page_title}")
+    parsed = mw.parse(page.text)
+    templates = parsed.filter_templates(matches=lambda tmpl: tmpl.name.strip() == TEMPLATE_NAME)
+    if not templates:
+        raise LookupError(f"Template '{TEMPLATE_NAME}' not found on {wiki_page_title}")
+    existing = str(templates[0].get(field).value).strip() if templates[0].has(field) else ""
+    if existing:
+        raise ValueError(
+            f"Wiki field '{field}' on {wiki_page_title} is already set to '{existing}'. "
+            f"Refusing to clobber. If the existing value is broken, clear it manually first."
+        )
+
+
+def restore(
+    *,
+    video_path: Path,
+    wiki_page_title: str,
+    season: str,
+    competition: str,
+    round_name: str,
+    opponent: str,
+    maccabi_score: int,
+    opponent_score: int,
+    video_type: VideoType,
+) -> str:
+    if not video_path.is_file():
+        raise FileNotFoundError(f"Backup video not found: {video_path}")
+
+    wiki_field = VIDEO_TYPE_TO_WIKI_FIELD[video_type]
+    site = get_site()
+    _check_wiki_field_empty(site, wiki_page_title, wiki_field)
+
+    youtube_title = format_video_title(
+        season=season,
+        competition=competition,
+        round_name=round_name,
+        maccabi_score=maccabi_score,
+        opponent=opponent,
+        opponent_score=opponent_score,
+        video_type=video_type,
+    )
+    description = wiki_page_url(wiki_page_title)
+    playlist_title = season_playlist_title(season)
+
+    logger.info("Uploading %s as %r to %r", video_path, youtube_title, playlist_title)
+    video_id = upload_and_add_to_playlist(video_path, youtube_title, playlist_title, description)
+    video_url = f"https://www.youtube.com/watch?v={video_id}"
+    logger.info("Uploaded %s — now updating wiki field %r on %s", video_url, wiki_field, wiki_page_title)
+
+    try:
+        set_video_field(site, wiki_page_title, wiki_field, video_url)
+    except Exception:
+        logger.exception(
+            "Upload succeeded (%s) but wiki update failed. Run update_wiki_video_field "
+            "manually with --page %r --field %r --url %s",
+            video_url, wiki_page_title, wiki_field, video_url,
+        )
+        raise
+    return video_id
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--file", required=True, help="Path to backup video file")
+    parser.add_argument("--wiki-page", required=True, help="Full wiki page title (e.g. 'משחק:...')")
+    parser.add_argument("--season", required=True, help="Season in YYYY-YY form (e.g. 2008-09)")
+    parser.add_argument("--competition", required=True, help="Competition name as it appears on the wiki page")
+    parser.add_argument("--round", dest="round_name", required=True, help="Round name (e.g. 'מחזור 21', 'סיבוב ט')")
+    parser.add_argument("--opponent", required=True, help="Opponent team name")
+    parser.add_argument("--maccabi-score", type=int, required=True)
+    parser.add_argument("--opponent-score", type=int, required=True)
+    parser.add_argument(
+        "--video-type", required=True, choices=sorted(CLI_VIDEO_TYPE_TO_INTERNAL.keys()),
+    )
+    args = parser.parse_args()
+
+    setup_logging(level=logging.INFO)
+    pw.config.verbose_output = False
+
+    video_id = restore(
+        video_path=Path(args.file),
+        wiki_page_title=args.wiki_page,
+        season=args.season,
+        competition=args.competition,
+        round_name=args.round_name,
+        opponent=args.opponent,
+        maccabi_score=args.maccabi_score,
+        opponent_score=args.opponent_score,
+        video_type=CLI_VIDEO_TYPE_TO_INTERNAL[args.video_type],
+    )
+    logger.info("Done. https://www.youtube.com/watch?v=%s", video_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/restore_deleted_football_video.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/restore_deleted_football_video.py
@@ -20,6 +20,7 @@ tables; a ball-sports variant can reuse the youtube/ helpers if needed.
 """
 import argparse
 import logging
+import shlex
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
@@ -161,10 +162,18 @@ def restore(
     try:
         set_video_field(site, wiki_page_title, wiki_field, video_url)
     except Exception:
+        # Build a copy-pasteable recovery command — %r wraps Hebrew strings in single
+        # quotes that the shell re-interprets, breaking the paste. shlex.quote emits
+        # shell-safe quoting that survives a real copy-paste.
+        recovery = " ".join([
+            "uv run python -m maccabipediabot.maintenance.videos.update_wiki_video_field",
+            f"--page {shlex.quote(wiki_page_title)}",
+            f"--field {shlex.quote(wiki_field)}",
+            f"--url {shlex.quote(video_url)}",
+        ])
         logger.exception(
-            "Upload succeeded (%s) but wiki update failed. Run update_wiki_video_field "
-            "manually with --page %r --field %r --url %s",
-            video_url, wiki_page_title, wiki_field, video_url,
+            "Upload succeeded (%s) but wiki update failed. Run this to finish the job:\n%s",
+            video_url, recovery,
         )
         raise
     return video_id

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/update_wiki_video_field.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/update_wiki_video_field.py
@@ -36,11 +36,9 @@ def set_video_field(site: pw.Site, page_title: str, field: str, url: str, summar
     if existing:
         raise ValueError(f"Field '{field}' already has a value on {page_title}: {existing}")
 
-    if tmpl.has(field):
-        tmpl.get(field).value = f"{url}\n"
-    else:
-        tmpl.add(field, f"{url}\n")
-
+    # mwparserfromhell's `add` replaces an existing parameter in place — same pattern
+    # as football/gamesbot.py and volleyball/gamesbot_volleyball.py.
+    tmpl.add(field, f"{url}\n")
     page.text = str(parsed)
     page.save(summary=summary or default_summary(url), bot=True)
 

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/update_wiki_video_field.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/update_wiki_video_field.py
@@ -1,0 +1,64 @@
+"""Set a video-link field (משחק מלא / תקציר וידאו / תקציר וידאו2) on a football game page."""
+import argparse
+import logging
+
+import mwparserfromhell as mw
+import pywikibot as pw
+
+from maccabipediabot.common.logging_setup import setup_logging
+from maccabipediabot.common.wiki_login import get_site
+
+logger = logging.getLogger(__name__)
+
+TEMPLATE_NAME = "קטלוג משחקים"
+ALLOWED_FIELDS = {"משחק מלא", "תקציר וידאו", "תקציר וידאו2"}
+
+
+def default_summary(video_url: str) -> str:
+    return f"MaccabiBot - Restore video link from backup upload ({video_url})"
+
+
+def set_video_field(site: pw.Site, page_title: str, field: str, url: str, summary: str | None = None) -> None:
+    if field not in ALLOWED_FIELDS:
+        raise ValueError(f"field must be one of {sorted(ALLOWED_FIELDS)}, got {field!r}")
+
+    page = pw.Page(site, page_title)
+    if not page.exists():
+        raise LookupError(f"Page not found: {page_title}")
+
+    parsed = mw.parse(page.text)
+    templates = parsed.filter_templates(matches=lambda t: t.name.strip() == TEMPLATE_NAME)
+    if not templates:
+        raise LookupError(f"Template '{TEMPLATE_NAME}' not found on {page_title}")
+    tmpl = templates[0]
+
+    existing = str(tmpl.get(field).value).strip() if tmpl.has(field) else ""
+    if existing:
+        raise ValueError(f"Field '{field}' already has a value on {page_title}: {existing}")
+
+    if tmpl.has(field):
+        tmpl.get(field).value = f"{url}\n"
+    else:
+        tmpl.add(field, f"{url}\n")
+
+    page.text = str(parsed)
+    page.save(summary=summary or default_summary(url), bot=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--page", required=True, help="Full page title incl. namespace (e.g. 'משחק:16-02-2009 ...')")
+    parser.add_argument("--field", required=True, choices=sorted(ALLOWED_FIELDS))
+    parser.add_argument("--url", required=True, help="YouTube URL to set")
+    parser.add_argument("--summary", default=None, help="Edit summary (default: auto-generated from URL)")
+    args = parser.parse_args()
+
+    setup_logging(level=logging.INFO)
+    pw.config.verbose_output = False
+    site = get_site()
+    set_video_field(site, args.page, args.field, args.url, args.summary)
+    logger.info("Updated %s on %s", args.field, args.page)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/auth.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/auth.py
@@ -34,8 +34,21 @@ def run_auth_flow() -> None:
         open_browser=False,
         prompt="select_account consent",
     )
-    TOKEN_FILE.write_text(creds.to_json())
+    _save_token(creds.to_json())
     print(f"Token saved to {TOKEN_FILE}")
+
+
+def _save_token(token_json: str) -> None:
+    """Write the OAuth token with owner-only permissions.
+
+    The default umask leaves files world-readable; an OAuth token granting upload +
+    playlist-management on our YouTube channel shouldn't be.
+    """
+    TOKEN_FILE.write_text(token_json)
+    try:
+        TOKEN_FILE.chmod(0o600)
+    except OSError:
+        pass  # chmod is best-effort on WSL/Windows; no loss of functionality.
 
 
 if __name__ == "__main__":

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/auth.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/auth.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+SCOPES = [
+    "https://www.googleapis.com/auth/youtube.upload",
+    "https://www.googleapis.com/auth/youtube",
+]
+CONFIG_DIR = Path.home() / ".config/maccabipedia"
+CLIENT_SECRET = CONFIG_DIR / "youtube_client_secret.json"
+TOKEN_FILE = CONFIG_DIR / "youtube_token.json"
+
+
+def run_auth_flow() -> None:
+    """Run OAuth flow against MaccabiPedia's Google project and save the token.
+
+    Prints the auth URL; approve in a browser on the same machine (port 8080 must be
+    accessible from the browser). The token is refreshable for ~7 days while the OAuth
+    app stays in Testing mode.
+
+    Important: MaccabiPedia is a Google Brand Account. At the consent screen, select the
+    MaccabiPedia brand (not the default personal account) — otherwise the token will be
+    bound to an account with no channel and uploads will fail with "Channel not found".
+    """
+    if not CLIENT_SECRET.is_file():
+        raise SystemExit(
+            f"Client secret not found at {CLIENT_SECRET}. Download the OAuth 2.0 Desktop "
+            f"client credentials from Google Cloud Console and save them there."
+        )
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    flow = InstalledAppFlow.from_client_secrets_file(str(CLIENT_SECRET), SCOPES)
+    creds = flow.run_local_server(
+        port=8080,
+        open_browser=False,
+        prompt="select_account consent",
+    )
+    TOKEN_FILE.write_text(creds.to_json())
+    print(f"Token saved to {TOKEN_FILE}")
+
+
+if __name__ == "__main__":
+    run_auth_flow()

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/client.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/client.py
@@ -67,8 +67,11 @@ def _verify_bound_to_maccabipedia(youtube) -> None:
 
 
 def find_playlist_id(youtube, title: str) -> str | None:
+    # The MaccabiPedia channel has ~30 playlists today, max ~200 realistically. Cap
+    # the paginated sweep at 20 pages (1000 playlists) so a misbehaving API can't hang.
     next_page_token = None
-    while True:
+    max_pages = 20
+    for _ in range(max_pages):
         resp = youtube.playlists().list(
             part="snippet",
             mine=True,
@@ -81,6 +84,10 @@ def find_playlist_id(youtube, title: str) -> str | None:
         next_page_token = resp.get("nextPageToken")
         if not next_page_token:
             return None
+    raise RuntimeError(
+        f"find_playlist_id: exceeded {max_pages} pages while searching for '{title}'. "
+        f"Channel has more playlists than the safety cap expects — bump max_pages."
+    )
 
 
 def create_playlist(youtube, title: str) -> str:
@@ -128,7 +135,7 @@ def upload_video(youtube, video_path: Path, title: str, description: str = "") -
 
 
 def add_video_to_playlist(youtube, playlist_id: str, video_id: str) -> None:
-    youtube.playlistItems().insert(
+    resp = youtube.playlistItems().insert(
         part="snippet",
         body={
             "snippet": {
@@ -137,5 +144,14 @@ def add_video_to_playlist(youtube, playlist_id: str, video_id: str) -> None:
             }
         },
     ).execute()
+    # Guard against silent insert failure (e.g. deleted/renamed playlist between
+    # ensure_playlist and this call). The API raises on HTTP errors; also verify the
+    # response carries the expected IDs so we don't report success on a no-op.
+    snippet = resp.get("snippet", {})
+    if snippet.get("playlistId") != playlist_id or snippet.get("resourceId", {}).get("videoId") != video_id:
+        raise RuntimeError(
+            f"Playlist insert returned an unexpected response: {resp!r} — video {video_id} "
+            f"may not have been added to playlist {playlist_id}"
+        )
 
 

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/client.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/client.py
@@ -1,0 +1,147 @@
+import logging
+from pathlib import Path
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+
+from maccabipediabot.maintenance.videos.youtube.auth import TOKEN_FILE
+
+logger = logging.getLogger(__name__)
+
+SPORTS_CATEGORY_ID = "17"
+MACCABIPEDIA_CHANNEL_ID = "UCxnAYpW-2OJUXbrSil5EeQQ"
+
+
+def youtube_client():
+    if not TOKEN_FILE.is_file():
+        raise SystemExit(
+            f"YouTube OAuth token not found at {TOKEN_FILE}. Run "
+            f"`uv run python -m maccabipediabot.maintenance.videos.youtube.auth` first."
+        )
+    creds = Credentials.from_authorized_user_file(str(TOKEN_FILE))
+    if creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+        TOKEN_FILE.write_text(creds.to_json())
+    client = build("youtube", "v3", credentials=creds)
+    _verify_bound_to_maccabipedia(client)
+    return client
+
+
+def _verify_bound_to_maccabipedia(youtube) -> None:
+    """Fail fast if the token authorizes some account other than @MaccabiPedia.
+
+    This catches the brand-account pitfall: a personal Google account can authenticate
+    successfully but not own any channel, or own a different one. Without this check
+    a mis-scoped token silently creates duplicate playlists under the wrong channel.
+    """
+    resp = youtube.channels().list(part="id", mine=True).execute()
+    items = resp.get("items", [])
+    if not items:
+        raise SystemExit(
+            "Authenticated Google account owns no YouTube channel. Re-run auth and pick "
+            "the MaccabiPedia brand account on the consent screen."
+        )
+    channel_id = items[0]["id"]
+    if channel_id != MACCABIPEDIA_CHANNEL_ID:
+        raise SystemExit(
+            f"Token is bound to channel {channel_id}, not MaccabiPedia "
+            f"({MACCABIPEDIA_CHANNEL_ID}). Re-run auth and pick MaccabiPedia."
+        )
+
+
+def find_playlist_id(youtube, title: str) -> str | None:
+    next_page_token = None
+    while True:
+        resp = youtube.playlists().list(
+            part="snippet",
+            mine=True,
+            maxResults=50,
+            pageToken=next_page_token,
+        ).execute()
+        for item in resp.get("items", []):
+            if item["snippet"]["title"] == title:
+                return item["id"]
+        next_page_token = resp.get("nextPageToken")
+        if not next_page_token:
+            return None
+
+
+def create_playlist(youtube, title: str) -> str:
+    resp = youtube.playlists().insert(
+        part="snippet,status",
+        body={
+            "snippet": {"title": title},
+            "status": {"privacyStatus": "public"},
+        },
+    ).execute()
+    return resp["id"]
+
+
+def ensure_playlist(youtube, title: str) -> str:
+    existing = find_playlist_id(youtube, title)
+    if existing:
+        return existing
+    return create_playlist(youtube, title)
+
+
+def upload_video(youtube, video_path: Path, title: str, description: str = "") -> str:
+    media = MediaFileUpload(str(video_path), resumable=True)
+    request = youtube.videos().insert(
+        part="snippet,status",
+        body={
+            "snippet": {
+                "title": title,
+                "description": description,
+                "categoryId": SPORTS_CATEGORY_ID,
+            },
+            "status": {
+                "privacyStatus": "public",
+                "selfDeclaredMadeForKids": False,
+            },
+        },
+        media_body=media,
+    )
+    response = None
+    while response is None:
+        status, response = request.next_chunk()
+        if status:
+            logger.info("Uploading... %d%%", int(status.progress() * 100))
+    return response["id"]
+
+
+def add_video_to_playlist(youtube, playlist_id: str, video_id: str) -> None:
+    youtube.playlistItems().insert(
+        part="snippet",
+        body={
+            "snippet": {
+                "playlistId": playlist_id,
+                "resourceId": {"kind": "youtube#video", "videoId": video_id},
+            }
+        },
+    ).execute()
+
+
+def update_video_snippet(youtube, video_id: str, title: str | None = None, description: str | None = None) -> None:
+    current = youtube.videos().list(part="snippet", id=video_id).execute()
+    items = current.get("items", [])
+    if not items:
+        raise LookupError(f"Video {video_id} not found on the channel")
+    snippet = items[0]["snippet"]
+    if title is not None:
+        snippet["title"] = title
+    if description is not None:
+        snippet["description"] = description
+    youtube.videos().update(
+        part="snippet",
+        body={"id": video_id, "snippet": snippet},
+    ).execute()
+
+
+def delete_video(youtube, video_id: str) -> None:
+    youtube.videos().delete(id=video_id).execute()
+
+
+def delete_playlist(youtube, playlist_id: str) -> None:
+    youtube.playlists().delete(id=playlist_id).execute()

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/client.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/client.py
@@ -13,6 +13,21 @@ logger = logging.getLogger(__name__)
 SPORTS_CATEGORY_ID = "17"
 MACCABIPEDIA_CHANNEL_ID = "UCxnAYpW-2OJUXbrSil5EeQQ"
 
+# Python's `mimetypes` misidentifies video extensions that share a suffix with
+# non-video formats (`.ts` → Qt Linguist, `.flv` sometimes missing). Override.
+_VIDEO_MIMETYPES = {
+    ".ts": "video/mp2t",
+    ".m2ts": "video/mp2t",
+    ".mts": "video/mp2t",
+    ".flv": "video/x-flv",
+    ".mkv": "video/x-matroska",
+    ".webm": "video/webm",
+    ".mp4": "video/mp4",
+    ".m4v": "video/mp4",
+    ".mov": "video/quicktime",
+    ".avi": "video/x-msvideo",
+}
+
 
 def youtube_client():
     if not TOKEN_FILE.is_file():
@@ -87,7 +102,8 @@ def ensure_playlist(youtube, title: str) -> str:
 
 
 def upload_video(youtube, video_path: Path, title: str, description: str = "") -> str:
-    media = MediaFileUpload(str(video_path), resumable=True)
+    mimetype = _VIDEO_MIMETYPES.get(video_path.suffix.lower())
+    media = MediaFileUpload(str(video_path), resumable=True, mimetype=mimetype)
     request = youtube.videos().insert(
         part="snippet,status",
         body={
@@ -123,25 +139,3 @@ def add_video_to_playlist(youtube, playlist_id: str, video_id: str) -> None:
     ).execute()
 
 
-def update_video_snippet(youtube, video_id: str, title: str | None = None, description: str | None = None) -> None:
-    current = youtube.videos().list(part="snippet", id=video_id).execute()
-    items = current.get("items", [])
-    if not items:
-        raise LookupError(f"Video {video_id} not found on the channel")
-    snippet = items[0]["snippet"]
-    if title is not None:
-        snippet["title"] = title
-    if description is not None:
-        snippet["description"] = description
-    youtube.videos().update(
-        part="snippet",
-        body={"id": video_id, "snippet": snippet},
-    ).execute()
-
-
-def delete_video(youtube, video_id: str) -> None:
-    youtube.videos().delete(id=video_id).execute()
-
-
-def delete_playlist(youtube, playlist_id: str) -> None:
-    youtube.playlists().delete(id=playlist_id).execute()

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/client.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/client.py
@@ -1,12 +1,13 @@
 import logging
 from pathlib import Path
 
+from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 
-from maccabipediabot.maintenance.videos.youtube.auth import TOKEN_FILE
+from maccabipediabot.maintenance.videos.youtube.auth import TOKEN_FILE, _save_token
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +38,15 @@ def youtube_client():
         )
     creds = Credentials.from_authorized_user_file(str(TOKEN_FILE))
     if creds.expired and creds.refresh_token:
-        creds.refresh(Request())
-        TOKEN_FILE.write_text(creds.to_json())
+        try:
+            creds.refresh(Request())
+        except RefreshError as error:
+            raise SystemExit(
+                f"OAuth refresh failed: {error}. The token likely expired (the OAuth app "
+                f"is in Testing mode, so refresh tokens are valid for ~7 days). Re-run "
+                f"`uv run python -m maccabipediabot.maintenance.videos.youtube.auth`."
+            ) from error
+        _save_token(creds.to_json())
     client = build("youtube", "v3", credentials=creds)
     _verify_bound_to_maccabipedia(client)
     return client
@@ -109,7 +117,17 @@ def ensure_playlist(youtube, title: str) -> str:
 
 
 def upload_video(youtube, video_path: Path, title: str, description: str = "") -> str:
-    mimetype = _VIDEO_MIMETYPES.get(video_path.suffix.lower())
+    suffix = video_path.suffix.lower()
+    mimetype = _VIDEO_MIMETYPES.get(suffix)
+    if mimetype is None:
+        # Python's mimetypes will kick in (the same path that produced the .ts bug).
+        # Warn loudly so the next unmapped extension surfaces in logs before YouTube
+        # rejects the upload.
+        logger.warning(
+            "No explicit mimetype for %s — falling back to Python's guess_type. If "
+            "this upload fails with 'Media type ... is not supported', add %s to "
+            "_VIDEO_MIMETYPES.", suffix, suffix,
+        )
     media = MediaFileUpload(str(video_path), resumable=True, mimetype=mimetype)
     request = youtube.videos().insert(
         part="snippet,status",

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/title.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/title.py
@@ -1,0 +1,49 @@
+"""Title formatter for MaccabiPedia YouTube uploads.
+
+Channel convention: teams listed with Maccabi first, score in parentheses at the end,
+digits stored reversed. YouTube's BIDI renderer flips digit order inside parens in RTL
+context; storing `(2-0)` causes the display to show `(0-2)`. Readers then interpret
+`Maccabi - Hapoel (0-2)` as Maccabi=0, Hapoel=2 — the intended semantics.
+
+Example:
+    format_video_title(
+        season="2008-09",
+        competition="גביע המדינה",
+        round_name="סיבוב ט",
+        maccabi_score=0,
+        opponent="הפועל תל אביב",
+        opponent_score=2,
+        video_type=HIGHLIGHTS,
+    )
+    → 'עונת 2008-09 גביע המדינה סיבוב ט מכבי תל אביב - הפועל תל אביב (2-0) תקציר'
+"""
+from typing import Literal
+
+MACCABI_TEAM = "מכבי תל אביב"
+FULL_MATCH = "משחק מלא"
+HIGHLIGHTS = "תקציר"
+
+VideoType = Literal["משחק מלא", "תקציר"]
+
+
+def format_video_title(
+    *,
+    season: str,
+    competition: str,
+    round_name: str,
+    maccabi_score: int,
+    opponent: str,
+    opponent_score: int,
+    video_type: VideoType,
+) -> str:
+    score_in_storage = f"({opponent_score}-{maccabi_score})"
+    return (
+        f"עונת {season} {competition} {round_name} "
+        f"{MACCABI_TEAM} - {opponent} {score_in_storage} {video_type}"
+    )
+
+
+def season_playlist_title(season: str) -> str:
+    """`2008-09` → `מכביפדיה | עונת 2008/09`."""
+    start, end = season.split("-")
+    return f"מכביפדיה | עונת {start}/{end}"

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/upload.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/upload.py
@@ -1,0 +1,47 @@
+"""Upload a backup video to MaccabiPedia's YouTube channel and add it to a season playlist.
+
+This is the YouTube-only step. For the full pipeline (upload + wiki page update) use
+`restore_deleted_football_video`.
+"""
+import argparse
+import logging
+from pathlib import Path
+
+from maccabipediabot.common.logging_setup import setup_logging
+from maccabipediabot.maintenance.videos.youtube.client import (
+    add_video_to_playlist,
+    ensure_playlist,
+    upload_video,
+    youtube_client,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def upload_and_add_to_playlist(video_path: Path, title: str, playlist_title: str, description: str) -> str:
+    youtube = youtube_client()
+    playlist_id = ensure_playlist(youtube, playlist_title)
+    video_id = upload_video(youtube, video_path, title, description)
+    add_video_to_playlist(youtube, playlist_id, video_id)
+    return video_id
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file", required=True, help="Path to video file")
+    parser.add_argument("--title", required=True, help="Video title (use title.format_video_title)")
+    parser.add_argument("--playlist", required=True, help="Playlist title, e.g. 'מכביפדיה | עונת 2008/09'")
+    parser.add_argument("--description", required=True, help="Description (typically the URL-encoded wiki page URL)")
+    args = parser.parse_args()
+
+    setup_logging(level=logging.INFO)
+    video_path = Path(args.file)
+    if not video_path.is_file():
+        raise SystemExit(f"File not found: {video_path}")
+
+    video_id = upload_and_add_to_playlist(video_path, args.title, args.playlist, args.description)
+    logger.info("Uploaded https://www.youtube.com/watch?v=%s", video_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/maccabipediabot/tests/maintenance/videos/test_restore_deleted_football_video.py
+++ b/packages/maccabipediabot/tests/maintenance/videos/test_restore_deleted_football_video.py
@@ -1,18 +1,73 @@
+import pytest
+
 from maccabipediabot.maintenance.videos.restore_deleted_football_video import (
+    GameMetadata,
     VIDEO_TYPE_TO_WIKI_FIELD,
+    parse_game_metadata,
     wiki_page_url,
 )
 from maccabipediabot.maintenance.videos.youtube.title import FULL_MATCH, HIGHLIGHTS
+
+
+def _game_page_wikitext(**overrides: str) -> str:
+    fields = {
+        "עונה": "2018/19",
+        "מפעל": "הליגה האירופית",
+        "שלב במפעל": "סיבוב שלישי - משחק 2",
+        "שם יריבה": "פיוניק",
+        "תוצאת משחק מכבי": "2",
+        "תוצאת משחק יריבה": "1",
+    }
+    fields.update(overrides)
+    lines = "\n".join(f"|{k}={v}" for k, v in fields.items())
+    return "{{קטלוג משחקים\n" + lines + "\n}}"
+
+
+def test_parse_game_metadata_reads_all_fields_and_normalizes_season():
+    result = parse_game_metadata(_game_page_wikitext(), page_title_hint="test")
+    assert result == GameMetadata(
+        season="2018-19",
+        competition="הליגה האירופית",
+        stage="סיבוב שלישי - משחק 2",
+        opponent="פיוניק",
+        maccabi_score=2,
+        opponent_score=1,
+    )
+
+
+def test_parse_game_metadata_normalizes_season_with_dash_already():
+    result = parse_game_metadata(_game_page_wikitext(**{"עונה": "2008-09"}), page_title_hint="test")
+    assert result.season == "2008-09"
+
+
+def test_parse_game_metadata_raises_when_template_missing():
+    with pytest.raises(LookupError, match="Template"):
+        parse_game_metadata("just some text with no template", page_title_hint="test")
+
+
+def test_parse_game_metadata_raises_on_missing_required_field():
+    wikitext = "{{קטלוג משחקים\n|עונה=2018/19\n|מפעל=הליגה האירופית\n}}"
+    with pytest.raises(LookupError, match="שלב במפעל"):
+        parse_game_metadata(wikitext, page_title_hint="test")
+
+
+def test_parse_game_metadata_raises_on_empty_required_field():
+    with pytest.raises(LookupError, match="שלב במפעל"):
+        parse_game_metadata(_game_page_wikitext(**{"שלב במפעל": ""}), page_title_hint="test")
+
+
+def test_parse_game_metadata_handles_whitespace_around_values():
+    wikitext = _game_page_wikitext(**{"שם יריבה": "  פיוניק  "})
+    assert parse_game_metadata(wikitext, page_title_hint="test").opponent == "פיוניק"
 
 
 def test_wiki_page_url_encodes_hebrew_characters():
     title = "משחק:16-02-2009 הפועל תל אביב נגד מכבי תל אביב - גביע המדינה"
     url = wiki_page_url(title)
     assert url.startswith("https://www.maccabipedia.co.il/")
-    # Underscore-separated and percent-encoded — ASCII-only so YouTube linkifies it.
     assert all(ord(c) < 128 for c in url)
-    assert "%D7%9E%D7%A9%D7%97%D7%A7" in url  # the "משחק" namespace
-    assert ":" in url  # namespace separator stayed literal
+    assert "%D7%9E%D7%A9%D7%97%D7%A7" in url
+    assert ":" in url
 
 
 def test_wiki_page_url_preserves_colon_namespace_separator():

--- a/packages/maccabipediabot/tests/maintenance/videos/test_restore_deleted_football_video.py
+++ b/packages/maccabipediabot/tests/maintenance/videos/test_restore_deleted_football_video.py
@@ -1,0 +1,25 @@
+from maccabipediabot.maintenance.videos.restore_deleted_football_video import (
+    VIDEO_TYPE_TO_WIKI_FIELD,
+    wiki_page_url,
+)
+from maccabipediabot.maintenance.videos.youtube.title import FULL_MATCH, HIGHLIGHTS
+
+
+def test_wiki_page_url_encodes_hebrew_characters():
+    title = "משחק:16-02-2009 הפועל תל אביב נגד מכבי תל אביב - גביע המדינה"
+    url = wiki_page_url(title)
+    assert url.startswith("https://www.maccabipedia.co.il/")
+    # Underscore-separated and percent-encoded — ASCII-only so YouTube linkifies it.
+    assert all(ord(c) < 128 for c in url)
+    assert "%D7%9E%D7%A9%D7%97%D7%A7" in url  # the "משחק" namespace
+    assert ":" in url  # namespace separator stayed literal
+
+
+def test_wiki_page_url_preserves_colon_namespace_separator():
+    assert wiki_page_url("משחק:foo") == "https://www.maccabipedia.co.il/" + "%D7%9E%D7%A9%D7%97%D7%A7" + ":foo"
+
+
+def test_video_type_to_wiki_field_covers_both_types():
+    assert VIDEO_TYPE_TO_WIKI_FIELD[FULL_MATCH] == "משחק מלא"
+    assert VIDEO_TYPE_TO_WIKI_FIELD[HIGHLIGHTS] == "תקציר וידאו"
+    assert set(VIDEO_TYPE_TO_WIKI_FIELD.keys()) == {FULL_MATCH, HIGHLIGHTS}

--- a/packages/maccabipediabot/tests/maintenance/videos/youtube/test_client.py
+++ b/packages/maccabipediabot/tests/maintenance/videos/youtube/test_client.py
@@ -1,0 +1,89 @@
+"""Tests for the runtime guards in `youtube/client.py` that were added in the PR
+review-fix pass (pagination safety cap; playlist-insert response verification).
+Without these, a future cleanup could silently remove the guards as paranoia.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from maccabipediabot.maintenance.videos.youtube.client import (
+    add_video_to_playlist,
+    find_playlist_id,
+)
+
+
+class _PaginatedPlaylists:
+    """Fake youtube.playlists() resource that always returns `nextPageToken`.
+
+    Used to exercise the safety-cap branch in `find_playlist_id` (a misbehaving or
+    unbounded API shouldn't hang the caller).
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def playlists(self):  # matches google-api-python-client's chained API
+        return self
+
+    def list(self, **_kwargs: Any):
+        return self
+
+    def execute(self) -> dict[str, Any]:
+        self.calls += 1
+        return {
+            "items": [{"snippet": {"title": f"fake-{self.calls}"}, "id": f"id-{self.calls}"}],
+            "nextPageToken": "always-more",
+        }
+
+
+def test_find_playlist_id_caps_pagination_at_20_pages():
+    fake = _PaginatedPlaylists()
+    with pytest.raises(RuntimeError, match="exceeded 20 pages"):
+        find_playlist_id(fake, "title-that-never-matches")
+    assert fake.calls == 20
+
+
+def test_find_playlist_id_returns_match_without_full_sweep():
+    fake = Mock()
+    fake.playlists.return_value.list.return_value.execute.return_value = {
+        "items": [
+            {"snippet": {"title": "other"}, "id": "pl-other"},
+            {"snippet": {"title": "target"}, "id": "pl-target"},
+        ],
+    }
+    assert find_playlist_id(fake, "target") == "pl-target"
+
+
+def test_find_playlist_id_returns_none_when_channel_has_no_match():
+    fake = Mock()
+    fake.playlists.return_value.list.return_value.execute.return_value = {
+        "items": [{"snippet": {"title": "unrelated"}, "id": "pl-1"}],
+    }
+    assert find_playlist_id(fake, "missing") is None
+
+
+def test_add_video_to_playlist_raises_when_response_ids_mismatch():
+    fake = Mock()
+    # Response for a DIFFERENT video — simulates silent no-op / wrong write target.
+    fake.playlistItems.return_value.insert.return_value.execute.return_value = {
+        "snippet": {
+            "playlistId": "wrong-playlist",
+            "resourceId": {"kind": "youtube#video", "videoId": "wrong-video"},
+        }
+    }
+    with pytest.raises(RuntimeError, match="unexpected response"):
+        add_video_to_playlist(fake, playlist_id="expected-playlist", video_id="expected-video")
+
+
+def test_add_video_to_playlist_succeeds_when_response_matches():
+    fake = Mock()
+    fake.playlistItems.return_value.insert.return_value.execute.return_value = {
+        "snippet": {
+            "playlistId": "the-playlist",
+            "resourceId": {"kind": "youtube#video", "videoId": "the-video"},
+        }
+    }
+    add_video_to_playlist(fake, playlist_id="the-playlist", video_id="the-video")

--- a/packages/maccabipediabot/tests/maintenance/videos/youtube/test_title.py
+++ b/packages/maccabipediabot/tests/maintenance/videos/youtube/test_title.py
@@ -40,18 +40,20 @@ def test_format_full_match_with_win():
     )
 
 
-def test_format_draw_still_reverses():
-    # 2018-19 Europa League 1st qualifying round, 12-07-2018 in Budapest: 1-1.
+def test_format_score_is_stored_opponent_first_for_bidi():
+    # Explicit non-palindrome check: Maccabi 3, Ajax 2 must appear as "(2-3)" in storage
+    # so the BIDI renderer flips it to "(3-2)" visually — Hebrew readers see Maccabi=3.
     title = format_video_title(
-        season="2018-19",
-        competition="הליגה האירופית",
-        round_name="מוקדמות ראשונות",
-        maccabi_score=1,
-        opponent="פרנצווארוש",
-        opponent_score=1,
+        season="2004-05",
+        competition="ליגת האלופות",
+        round_name="שלב הבתים - מחזור 4",
+        maccabi_score=3,
+        opponent="אייאקס אמסטרדם",
+        opponent_score=2,
         video_type=FULL_MATCH,
     )
-    assert "(1-1)" in title
+    assert "(2-3)" in title
+    assert "(3-2)" not in title
 
 
 def test_season_playlist_title():

--- a/packages/maccabipediabot/tests/maintenance/videos/youtube/test_title.py
+++ b/packages/maccabipediabot/tests/maintenance/videos/youtube/test_title.py
@@ -1,0 +1,59 @@
+from maccabipediabot.maintenance.videos.youtube.title import (
+    FULL_MATCH,
+    HIGHLIGHTS,
+    format_video_title,
+    season_playlist_title,
+)
+
+
+def test_format_highlights_with_loss_reverses_score_for_bidi():
+    # Maccabi TA lost 0-2 at Hapoel TA, State Cup round 9, 16-02-2009.
+    title = format_video_title(
+        season="2008-09",
+        competition="גביע המדינה",
+        round_name="סיבוב ט",
+        maccabi_score=0,
+        opponent="הפועל תל אביב",
+        opponent_score=2,
+        video_type=HIGHLIGHTS,
+    )
+    assert title == (
+        "עונת 2008-09 גביע המדינה סיבוב ט "
+        "מכבי תל אביב - הפועל תל אביב (2-0) תקציר"
+    )
+
+
+def test_format_full_match_with_win():
+    # 1995-96 championship-clinching win vs Beitar: Maccabi TA 3-1 Beitar Jerusalem.
+    title = format_video_title(
+        season="1995-96",
+        competition="ליגה לאומית",
+        round_name="מחזור 34",
+        maccabi_score=3,
+        opponent="ביתר ירושלים",
+        opponent_score=1,
+        video_type=FULL_MATCH,
+    )
+    assert title == (
+        "עונת 1995-96 ליגה לאומית מחזור 34 "
+        "מכבי תל אביב - ביתר ירושלים (1-3) משחק מלא"
+    )
+
+
+def test_format_draw_still_reverses():
+    # 2018-19 Europa League 1st qualifying round, 12-07-2018 in Budapest: 1-1.
+    title = format_video_title(
+        season="2018-19",
+        competition="הליגה האירופית",
+        round_name="מוקדמות ראשונות",
+        maccabi_score=1,
+        opponent="פרנצווארוש",
+        opponent_score=1,
+        video_type=FULL_MATCH,
+    )
+    assert "(1-1)" in title
+
+
+def test_season_playlist_title():
+    assert season_playlist_title("2008-09") == "מכביפדיה | עונת 2008/09"
+    assert season_playlist_title("1999-00") == "מכביפדיה | עונת 1999/00"


### PR DESCRIPTION
## Summary
- One-command flow to restore a deleted football video: upload local backup → MaccabiPedia channel → link it on the wiki game page
- Pre-flight aborts if the target wiki field is already set, so we never clobber a working link
- New sport-agnostic `youtube/` submodule (auth, client, title formatter, upload+playlist) so a ball-sports variant can reuse it later

## Why
11 football videos referenced from wiki game pages were deleted from their external YouTube homes on 2026-04-18. We have local backups and our own channel (@MaccabiPedia) — this PR is the automation to push a backup back onto YouTube and relink it on the wiki. Game 4 (2008-09 State Cup, Hapoel TA vs Maccabi TA) was done manually end-to-end to shake out the flow; this PR promotes the working logic into the package.

## Key design choices
- **Packaging as a monorepo submodule** rather than MCP or `.claude/scripts/` — follows the existing neighbor pattern (`find_broken_videos.py`, `extract_links.py`). Reviewer agreed after an explicit packaging-style review.
- **Title format uses BIDI-aware score reversal.** YouTube's renderer flips digit order inside parens in RTL context, so the score is stored as `(opponent-maccabi)` to display as `(maccabi-opponent)`. Convention documented in `.claude/maccabipedia_youtube_channel.md`.
- **Brand-account guard.** `youtube_client()` verifies the token is bound to MaccabiPedia's channel ID (`UCxnAYpW-2OJUXbrSil5EeQQ`) and fails fast otherwise, after a real incident where the initial auth landed on a brand-less personal account.
- **No atomic rollback on partial failure.** If upload succeeds but the wiki edit fails, the video URL is logged loudly with the exact `update_wiki_video_field` command for manual recovery. YouTube uploads cost 1,600 quota units (6/day cap), so rollback-by-retry is worse than logging.

## Files
- `packages/maccabipediabot/src/maccabipediabot/maintenance/videos/youtube/{auth,client,title,upload}.py` — sport-agnostic YouTube helpers
- `packages/maccabipediabot/src/maccabipediabot/maintenance/videos/update_wiki_video_field.py` — football wiki-field setter
- `packages/maccabipediabot/src/maccabipediabot/maintenance/videos/restore_deleted_football_video.py` — end-to-end orchestrator CLI
- `.claude/maccabipedia_youtube_channel.md` — channel conventions doc (title format, playlists, OAuth gotchas, backup folder layout)

## Test plan
- [x] `uv run pytest` — 105 tests passing (7 new)
- [x] Manual end-to-end: game 4 uploaded + playlist created + wiki field set — verified by user in-browser (title renders correctly, description URL clickable)
- [ ] Dogfood the new CLI by uploading games 2, 5, 6, 7, 8, 9, 10 after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)