### PR TITLE
refactor(dev): split local-wiki LocalSettings into shared + env files

### DIFF
--- a/infra/local-wiki/.env.example
+++ b/infra/local-wiki/.env.example
@@ -1,0 +1,20 @@
+# Template for infra/local-wiki/.env — copy this file to `.env` and fill in.
+# The .env file is gitignored. After creating it:
+#   chmod 600 infra/local-wiki/.env
+# so only your user can read it.
+
+MACCABIPEDIA_FTP_HOST=ftp.example.com
+MACCABIPEDIA_FTP_USER=changeme
+MACCABIPEDIA_FTP_PASS=changeme
+MACCABIPEDIA_FTP_REMOTE_ROOT=/public_html
+
+# Set to 1 to hard-require TLS on the FTP control channel (recommended).
+# Leave unset or 0 for opportunistic TLS (lftp uses TLS if the server
+# advertises it, falls back to plain FTP otherwise).
+MACCABIPEDIA_FTP_REQUIRE_TLS=1
+
+# Set to 1 to require the FTP server's TLS cert to be signed by a
+# system-trusted CA. Default is 0 because shared hosts often present
+# self-signed certs — TLS encryption still protects the password on the
+# wire, only cert identity verification is skipped.
+MACCABIPEDIA_FTP_TLS_VERIFY=0

--- a/infra/local-wiki/.gitignore
+++ b/infra/local-wiki/.gitignore
@@ -1,0 +1,2 @@
+.env
+synced/

--- a/infra/local-wiki/.gitignore
+++ b/infra/local-wiki/.gitignore
@@ -1,2 +1,3 @@
 .env
 synced/
+prod-upload/LocalSettings.env.prod.php

--- a/infra/local-wiki/Dockerfile
+++ b/infra/local-wiki/Dockerfile
@@ -1,0 +1,42 @@
+FROM php:7.4-apache
+
+ENV MW_VERSION=1.39.11 \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libicu-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libfreetype6-dev \
+        libzip-dev \
+        libonig-dev \
+        unzip \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j"$(nproc)" \
+        calendar \
+        gd \
+        intl \
+        mbstring \
+        mysqli \
+        opcache \
+        zip
+
+RUN pecl install apcu && docker-php-ext-enable apcu
+
+RUN a2enmod rewrite
+
+RUN curl -fSL "https://releases.wikimedia.org/mediawiki/1.39/mediawiki-${MW_VERSION}.tar.gz" -o /tmp/mediawiki.tar.gz \
+    && tar -xzf /tmp/mediawiki.tar.gz --strip-components=1 -C /var/www/html \
+    && rm /tmp/mediawiki.tar.gz \
+    && chown -R www-data:www-data /var/www/html
+
+WORKDIR /var/www/html
+
+COPY entrypoint.sh /usr/local/bin/mw-entrypoint.sh
+RUN chmod +x /usr/local/bin/mw-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/mw-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/infra/local-wiki/LocalSettings.env.local.php
+++ b/infra/local-wiki/LocalSettings.env.local.php
@@ -1,0 +1,62 @@
+<?php
+# Env-specific config for the local docker wiki.
+# Loaded by LocalSettings.php BEFORE LocalSettings.shared.php, so shared
+# code can reference vars set here ($wgScriptPath, $wgDBname, etc).
+#
+# Prod gets its own sibling (LocalSettings.env.prod.php, never committed
+# here) with the matching set of assignments. Keep the *set of variables*
+# in lock-step with that file — add a var here only after the prod
+# counterpart has a value for it.
+
+if (!defined('MEDIAWIKI')) {
+	exit;
+}
+
+## URL — no rewrite rules in the docker image, so article path keeps the
+## /index.php/ segment. Prod uses "/$1" with mod_rewrite.
+$wgServer = getenv('MW_SITE_SERVER') ?: 'http://localhost:8080';
+$wgScriptPath = '';
+$wgArticlePath = '/index.php/$1';
+
+## Email — disabled locally, no SMTP reachable.
+$wgEnableEmail = false;
+$wgEmailAuthentication = false;
+$wgEmergencyContact = 'dev@localhost';
+$wgPasswordSender = 'dev@localhost';
+
+## Database — values come from docker-compose environment.
+$wgDBtype = 'mysql';
+$wgDBserver = getenv('MW_DB_HOST') ?: 'mariadb';
+$wgDBname = getenv('MW_DB_NAME') ?: 'maccabipedia';
+$wgDBuser = getenv('MW_DB_USER') ?: 'mw';
+$wgDBpassword = getenv('MW_DB_PASSWORD') ?: 'devpass';
+$wgDBprefix = getenv('MW_DB_PREFIX') ?: 'MPMW_';
+
+## Cache — disabled so edits and template changes show immediately.
+$wgMainCacheType = CACHE_NONE;
+$wgMemCachedServers = [];
+
+## Secrets — placeholders only. Prod's env file carries the real values.
+$wgSecretKey = 'dev-secret-not-a-real-key-local-only';
+$wgUpgradeKey = 'dev-upgrade-key-local-only';
+
+## Logging — no files written (no /MyLogs dir in the container). Errors
+## surface on Apache's stderr, which docker compose captures.
+$wgDBerrorLog = false;
+$wgDebugLogGroups = [];
+$wgResourceLoaderDebug = true;
+$wgJobRunRate = 0;
+
+## Verbose error output — local debugging.
+$wgShowExceptionDetails = true;
+$wgShowDBErrorBacktrace = true;
+$wgShowSQLErrors = true;
+$wgDevelopmentWarnings = true;
+
+## SecureHTML — placeholder. The real prod secret never lives in this repo.
+$wgSecureHTMLSecrets = [
+	'Wiki admin' => 'dev-local-not-real',
+];
+
+## Google Analytics — empty id disables tracking from dev.
+$wgGTagAnalyticsId = '';

--- a/infra/local-wiki/LocalSettings.stub.php
+++ b/infra/local-wiki/LocalSettings.stub.php
@@ -1,0 +1,7 @@
+<?php
+# Bootstrap stub. Copied into place by entrypoint.sh after install.php runs.
+# Do NOT add config here — env-specific lines go in LocalSettings.env.*.php,
+# everything else in LocalSettings.shared.php.
+if (!defined('MEDIAWIKI')) { exit; }
+require_once __DIR__ . '/LocalSettings.env.local.php';
+require_once __DIR__ . '/LocalSettings.shared.php';

--- a/infra/local-wiki/README.md
+++ b/infra/local-wiki/README.md
@@ -1,0 +1,62 @@
+# Local MaccabiPedia (Docker) — v0
+
+A minimal local MediaWiki 1.39.11 + MariaDB running in Docker, matching prod's
+PHP 7.4 for extension parity. No prod skin/extensions/content yet — just a
+blank wiki so we have something running to iterate from.
+
+## Prerequisites
+
+- **Linux / WSL (Ubuntu/Debian):** run `./scripts/setup-host.sh` once. It
+  installs `docker.io`, `docker-compose-v2`, and `lftp`, starts the docker
+  daemon, and adds you to the `docker` group. After running it for the first
+  time, open a new shell (or `newgrp docker`) so `docker` works without sudo.
+- **macOS / Windows:** install Docker Desktop manually (with WSL 2 integration
+  on Windows). `lftp` is only needed for the prod-sync scripts and can be
+  installed via Homebrew / Scoop when you reach that step.
+
+## Bring it up
+
+```bash
+cd infra/local-wiki
+docker compose up -d --build
+```
+
+First boot takes a few minutes — builds the PHP 7.4 + MW 1.39.11 image and
+runs `maintenance/install.php`. Subsequent boots are fast.
+
+Then open http://localhost:8080.
+
+Admin user: `admin` / `devadminpass` (values from `docker-compose.yml`;
+local-only, not secrets).
+
+## Tear down
+
+```bash
+docker compose down          # keep data
+docker compose down -v       # wipe DB + uploaded images + LocalSettings
+```
+
+## What's here
+
+- `Dockerfile` — `FROM php:7.4-apache`, installs MW 1.39.11 + required PHP
+  extensions (intl, gd, mysqli, zip, mbstring, calendar, opcache, apcu).
+- `docker-compose.yml` — `mediawiki` service (built from `Dockerfile`) +
+  `mariadb:10`. Three named volumes: `mw_db`, `mw_images`, `mw_config`
+  (LocalSettings.php lives in `mw_config` so it survives container recreation).
+- `entrypoint.sh` — on first boot runs `install.php`, appends dev overrides to
+  the generated `LocalSettings.php`, symlinks it into place, then runs
+  `update.php --quick` on every boot.
+- `scripts/setup-host.sh` — one-shot host-prereq installer (docker, compose,
+  lftp). Idempotent; safe to re-run.
+- `scripts/sync-from-prod.sh` — named-op wrapper around `lftp` for pulling
+  files from the production FTP server. See `.env.example` for the required
+  environment variables; copy it to `.env` (gitignored) and `chmod 600`.
+
+## Not here yet
+
+- MaccabiPedia skin (pulled from prod via FTP in a future step)
+- Extensions from prod (Cargo, ParserFunctions, etc.)
+- Any seeded content
+- Bot-target integration
+
+These come in follow-up iterations once v0 is verified.

--- a/infra/local-wiki/docker-compose.yml
+++ b/infra/local-wiki/docker-compose.yml
@@ -22,7 +22,9 @@ services:
       - mw_images:/var/www/html/images
       - ./synced/skins/Metrolook:/var/www/html/skins/Metrolook:ro
       - ./synced/extensions:/var/www/html/extensions:ro
-      - ./synced/LocalSettings.prod-snapshot.php:/var/www/html/LocalSettings.prod-snapshot.php:ro
+      - ./prod-upload/LocalSettings.shared.php:/var/www/html/LocalSettings.shared.php:ro
+      - ./LocalSettings.env.local.php:/var/www/html/LocalSettings.env.local.php:ro
+      - ./LocalSettings.stub.php:/var/www/html/LocalSettings.stub.php:ro
 
   mariadb:
     image: mariadb:10

--- a/infra/local-wiki/docker-compose.yml
+++ b/infra/local-wiki/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  mediawiki:
+    build: .
+    ports:
+      - "8080:80"
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    environment:
+      MW_DB_HOST: mariadb
+      MW_DB_NAME: maccabipedia
+      MW_DB_USER: mw
+      MW_DB_PASSWORD: devpass
+      MW_DB_PREFIX: "MPMW_"
+      MW_ADMIN_USER: admin
+      MW_ADMIN_PASSWORD: devadminpass
+      MW_SITE_NAME: "MaccabiPedia Dev"
+      MW_SITE_SERVER: "http://localhost:8080"
+      MW_SITE_LANG: "he"
+    volumes:
+      - mw_config:/generated
+      - mw_images:/var/www/html/images
+      - ./synced/skins/Metrolook:/var/www/html/skins/Metrolook:ro
+      - ./synced/extensions:/var/www/html/extensions:ro
+      - ./synced/LocalSettings.prod-snapshot.php:/var/www/html/LocalSettings.prod-snapshot.php:ro
+
+  mariadb:
+    image: mariadb:10
+    environment:
+      MYSQL_DATABASE: maccabipedia
+      MYSQL_USER: mw
+      MYSQL_PASSWORD: devpass
+      MYSQL_ROOT_PASSWORD: devroot
+    volumes:
+      - mw_db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+volumes:
+  mw_config:
+  mw_images:
+  mw_db:

--- a/infra/local-wiki/entrypoint.sh
+++ b/infra/local-wiki/entrypoint.sh
@@ -2,22 +2,24 @@
 set -euo pipefail
 
 GENERATED_DIR=/generated
-GENERATED_LS="${GENERATED_DIR}/LocalSettings.php"
+INSTALLED_MARKER="${GENERATED_DIR}/.installed"
 ACTIVE_LS=/var/www/html/LocalSettings.php
-SNAPSHOT=/var/www/html/LocalSettings.prod-snapshot.php
+STUB=/var/www/html/LocalSettings.stub.php
 
 mkdir -p "$GENERATED_DIR"
 
-append_once() {
-    local marker="$1"
-    local block="$2"
-    if ! grep -qF "$marker" "$GENERATED_LS"; then
-        printf '\n%s\n%s\n' "$marker" "$block" >> "$GENERATED_LS"
-    fi
-}
+if [ ! -f "$STUB" ]; then
+    echo "[entrypoint] ERROR: $STUB not bind-mounted — check docker-compose.yml" >&2
+    exit 1
+fi
 
-if [ ! -f "$GENERATED_LS" ]; then
-    echo "[entrypoint] No LocalSettings.php found — running MediaWiki install.php"
+# First-boot install — writes the MediaWiki schema into the DB. The generated
+# LocalSettings.php from install.php goes to /tmp and is discarded; our
+# split-config stub is copied into place below. A marker file in the
+# persistent /generated volume tracks install state across container
+# restarts, so we don't re-run install.php every boot.
+if [ ! -f "$INSTALLED_MARKER" ]; then
+    echo "[entrypoint] First boot — running MediaWiki install.php"
 
     php maintenance/install.php \
         --dbtype=mysql \
@@ -32,63 +34,21 @@ if [ ! -f "$GENERATED_LS" ]; then
         --scriptpath="" \
         --lang="${MW_SITE_LANG}" \
         --pass="${MW_ADMIN_PASSWORD}" \
-        --confpath="${GENERATED_DIR}" \
+        --confpath=/tmp \
         "${MW_SITE_NAME}" \
         "${MW_ADMIN_USER}"
 
+    touch "$INSTALLED_MARKER"
     echo "[entrypoint] Install complete."
 fi
 
-# First layer of dev overrides — applied even when no prod snapshot is present.
-append_once "# --- dev overrides (appended by entrypoint.sh) ---" \
-'$wgMainCacheType = CACHE_NONE;
-$wgShowExceptionDetails = true;
-$wgShowDBErrorBacktrace = true;
-$wgShowSQLErrors = true;
-$wgDevelopmentWarnings = true;'
-
-# If the prod snapshot is mounted we load it, then re-assert dev-only values
-# AFTER the include so that prod secrets/URLs don't leak into runtime. PHP
-# executes top-to-bottom and the last assignment wins, so this block is our
-# "sanitization by override" in place of editing the snapshot on disk.
-if [ -f "$SNAPSHOT" ]; then
-    append_once "# --- prod snapshot include ---" \
-"if ( is_readable( '${SNAPSHOT}' ) ) {
-    require_once '${SNAPSHOT}';
-}"
-
-    append_once "# --- dev re-assert AFTER prod snapshot (wins by load order) ---" \
-"\$wgServer = '${MW_SITE_SERVER}';
-\$wgScriptPath = '';
-\$wgArticlePath = '/index.php/\$1';
-\$wgDBtype = 'mysql';
-\$wgDBserver = '${MW_DB_HOST}';
-\$wgDBname = '${MW_DB_NAME}';
-\$wgDBuser = '${MW_DB_USER}';
-\$wgDBpassword = '${MW_DB_PASSWORD}';
-\$wgDBprefix = '${MW_DB_PREFIX:-}';
-\$wgSecretKey = 'dev-secret-not-a-real-key-local-only';
-\$wgUpgradeKey = 'dev-upgrade-key-local-only';
-\$wgMainCacheType = CACHE_NONE;
-\$wgMemCachedServers = [];
-\$wgCacheDirectory = false;
-\$wgDBerrorLog = false;
-\$wgDebugLogFile = '';
-\$wgDebugLogGroups = [];
-\$wgShowExceptionDetails = true;
-\$wgShowDBErrorBacktrace = true;
-\$wgShowSQLErrors = true;
-\$wgDevelopmentWarnings = true;"
-else
-    # No snapshot — load just the skin so the wiki at least has branding.
-    if [ -d /var/www/html/skins/Metrolook ]; then
-        append_once "# --- skin: Metrolook (fallback when no snapshot) ---" \
-"wfLoadSkin( 'Metrolook' );
-\$wgDefaultSkin = 'metrolook';"
-    fi
-fi
-
-ln -sf "$GENERATED_LS" "$ACTIVE_LS"
+# Copy the split-config stub into place every boot. /var/www/html/ is image
+# filesystem and resets on container recreation, so this must run each time.
+# A real file (not symlink) is required: PHP's __DIR__ resolves to the real
+# path of the script, so symlinking the stub would break the sibling
+# require_once of LocalSettings.env.local.php / LocalSettings.shared.php
+# which are bind-mounted as siblings in /var/www/html/.
+cp "$STUB" "$ACTIVE_LS"
 
 echo "[entrypoint] Running maintenance/update.php --quick"
 php maintenance/update.php --quick

--- a/infra/local-wiki/entrypoint.sh
+++ b/infra/local-wiki/entrypoint.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -euo pipefail
+
+GENERATED_DIR=/generated
+GENERATED_LS="${GENERATED_DIR}/LocalSettings.php"
+ACTIVE_LS=/var/www/html/LocalSettings.php
+SNAPSHOT=/var/www/html/LocalSettings.prod-snapshot.php
+
+mkdir -p "$GENERATED_DIR"
+
+append_once() {
+    local marker="$1"
+    local block="$2"
+    if ! grep -qF "$marker" "$GENERATED_LS"; then
+        printf '\n%s\n%s\n' "$marker" "$block" >> "$GENERATED_LS"
+    fi
+}
+
+if [ ! -f "$GENERATED_LS" ]; then
+    echo "[entrypoint] No LocalSettings.php found — running MediaWiki install.php"
+
+    php maintenance/install.php \
+        --dbtype=mysql \
+        --dbserver="${MW_DB_HOST}" \
+        --dbname="${MW_DB_NAME}" \
+        --dbuser="${MW_DB_USER}" \
+        --dbpass="${MW_DB_PASSWORD}" \
+        --dbprefix="${MW_DB_PREFIX:-}" \
+        --installdbuser="${MW_DB_USER}" \
+        --installdbpass="${MW_DB_PASSWORD}" \
+        --server="${MW_SITE_SERVER}" \
+        --scriptpath="" \
+        --lang="${MW_SITE_LANG}" \
+        --pass="${MW_ADMIN_PASSWORD}" \
+        --confpath="${GENERATED_DIR}" \
+        "${MW_SITE_NAME}" \
+        "${MW_ADMIN_USER}"
+
+    echo "[entrypoint] Install complete."
+fi
+
+# First layer of dev overrides — applied even when no prod snapshot is present.
+append_once "# --- dev overrides (appended by entrypoint.sh) ---" \
+'$wgMainCacheType = CACHE_NONE;
+$wgShowExceptionDetails = true;
+$wgShowDBErrorBacktrace = true;
+$wgShowSQLErrors = true;
+$wgDevelopmentWarnings = true;'
+
+# If the prod snapshot is mounted we load it, then re-assert dev-only values
+# AFTER the include so that prod secrets/URLs don't leak into runtime. PHP
+# executes top-to-bottom and the last assignment wins, so this block is our
+# "sanitization by override" in place of editing the snapshot on disk.
+if [ -f "$SNAPSHOT" ]; then
+    append_once "# --- prod snapshot include ---" \
+"if ( is_readable( '${SNAPSHOT}' ) ) {
+    require_once '${SNAPSHOT}';
+}"
+
+    append_once "# --- dev re-assert AFTER prod snapshot (wins by load order) ---" \
+"\$wgServer = '${MW_SITE_SERVER}';
+\$wgScriptPath = '';
+\$wgArticlePath = '/index.php/\$1';
+\$wgDBtype = 'mysql';
+\$wgDBserver = '${MW_DB_HOST}';
+\$wgDBname = '${MW_DB_NAME}';
+\$wgDBuser = '${MW_DB_USER}';
+\$wgDBpassword = '${MW_DB_PASSWORD}';
+\$wgDBprefix = '${MW_DB_PREFIX:-}';
+\$wgSecretKey = 'dev-secret-not-a-real-key-local-only';
+\$wgUpgradeKey = 'dev-upgrade-key-local-only';
+\$wgMainCacheType = CACHE_NONE;
+\$wgMemCachedServers = [];
+\$wgCacheDirectory = false;
+\$wgDBerrorLog = false;
+\$wgDebugLogFile = '';
+\$wgDebugLogGroups = [];
+\$wgShowExceptionDetails = true;
+\$wgShowDBErrorBacktrace = true;
+\$wgShowSQLErrors = true;
+\$wgDevelopmentWarnings = true;"
+else
+    # No snapshot — load just the skin so the wiki at least has branding.
+    if [ -d /var/www/html/skins/Metrolook ]; then
+        append_once "# --- skin: Metrolook (fallback when no snapshot) ---" \
+"wfLoadSkin( 'Metrolook' );
+\$wgDefaultSkin = 'metrolook';"
+    fi
+fi
+
+ln -sf "$GENERATED_LS" "$ACTIVE_LS"
+
+echo "[entrypoint] Running maintenance/update.php --quick"
+php maintenance/update.php --quick
+
+exec "$@"

--- a/infra/local-wiki/prod-upload/LocalSettings.php
+++ b/infra/local-wiki/prod-upload/LocalSettings.php
@@ -1,0 +1,7 @@
+<?php
+# Bootstrap for production. Loads env-specific values first, then the
+# site-wide shared config. All three files must be uploaded as siblings
+# to the wiki root.
+if (!defined('MEDIAWIKI')) { exit; }
+require_once __DIR__ . '/LocalSettings.env.prod.php';
+require_once __DIR__ . '/LocalSettings.shared.php';

--- a/infra/local-wiki/prod-upload/LocalSettings.shared.php
+++ b/infra/local-wiki/prod-upload/LocalSettings.shared.php
@@ -1,0 +1,403 @@
+<?php
+# Site-wide MediaWiki config for MaccabiPedia. Loaded by LocalSettings.php
+# AFTER LocalSettings.env.*.php so env-specific values (DB, URL, secrets,
+# cache, logs, debug verbosity) are already set. Do NOT put env-specific
+# lines here — see LocalSettings.env.local.php / LocalSettings.env.prod.php.
+#
+# See includes/DefaultSettings.php for all configurable settings
+# and their default values, but don't forget to make changes in _this_
+# file, not there.
+#
+# Further documentation for configuration settings may be found at:
+# https://www.mediawiki.org/wiki/Manual:Configuration_settings
+
+# Protect against web entry
+if (!defined('MEDIAWIKI')) {
+	exit;
+}
+
+## Uncomment this to disable output compression
+# $wgDisableOutputCompression = true;
+
+$wgSitename = "מכביפדיה";
+
+$wgLocaltimezone = "Asia/Jerusalem";
+
+
+## The URL base path to the directory containing the wiki;
+# $wgScriptPath — set in LocalSettings.env.*.php
+# $wgArticlePath — set in LocalSettings.env.*.php
+
+## The protocol and server name to use in fully-qualified URLs
+# $wgServer — set in LocalSettings.env.*.php
+
+## The URL path to static resources (images, scripts, etc.)
+$wgResourceBasePath = $wgScriptPath;
+
+
+## UPO means: this is also a user preference option
+
+# $wgEnableEmail — set in LocalSettings.env.*.php
+$wgEnableUserEmail = true; # UPO
+
+# $wgEmergencyContact — set in LocalSettings.env.*.php
+# $wgPasswordSender — set in LocalSettings.env.*.php
+
+$wgEnotifUserTalk = false; # UPO
+$wgEnotifWatchlist = false; # UPO
+# $wgEmailAuthentication — set in LocalSettings.env.*.php
+
+## Allow use <img> tag
+$wgAllowExternalImages = true; # -- due to upgrade
+
+## Database settings
+# $wgDBtype — set in LocalSettings.env.*.php
+# $wgDBserver — set in LocalSettings.env.*.php
+# $wgDBname — set in LocalSettings.env.*.php
+# $wgDBuser — set in LocalSettings.env.*.php
+# $wgDBpassword — set in LocalSettings.env.*.php
+
+
+# MySQL specific settings
+# $wgDBprefix — set in LocalSettings.env.*.php
+
+# MySQL table options to use during installation or update
+$wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=binary";
+
+## Shared memory settings
+# $wgMainCacheType — set in LocalSettings.env.*.php
+# $wgMemCachedServers — set in LocalSettings.env.*.php
+
+## Use file-system file caching (https://www.mediawiki.org/wiki/Manual:File_cache)
+## This seems to be not working well always, because the cache files name based on the page names (which contains hebrew) - they will be encoded and having too long path
+## $wgUseFileCache = true;
+
+## To enable image uploads, make sure the 'images' directory
+## is writable, then set this to true:
+$wgEnableUploads = true;
+// Add several file types to the default array
+$wgFileExtensions = array_merge($wgFileExtensions, ['pdf']);
+
+#$wgUseImageMagick = true;
+#$wgImageMagickConvertCommand = "/usr/bin/convert";
+
+# InstantCommons allows wiki to use images from https://commons.wikimedia.org
+$wgUseInstantCommons = false;
+
+# Periodically send a pingback to https://www.mediawiki.org/ with basic data
+# about this MediaWiki instance. The Wikimedia Foundation shares this data
+# with MediaWiki developers to help guide future development efforts.
+$wgPingback = true;
+
+## If you use ImageMagick (or any other shell command) on a
+## Linux server, this will need to be set to the name of an
+## available UTF-8 locale
+$wgShellLocale = "en_US.utf8";
+
+## Set $wgCacheDirectory to a writable directory on the web server
+## to make your wiki go slightly faster. The directory should not
+## be publically accessible from the web.
+#$wgCacheDirectory = "$IP/cache";
+
+# Site language code, should be one of the list in ./languages/data/Names.php
+$wgLanguageCode = "he";
+
+# $wgSecretKey — set in LocalSettings.env.*.php
+
+# Changing this will log out all existing sessions.
+$wgAuthenticationTokenVersion = "1";
+
+# Site upgrade key. Must be set to a string (default provided) to turn on the
+# web installer while LocalSettings.php is in place
+# $wgUpgradeKey — set in LocalSettings.env.*.php
+
+## For attaching licensing metadata to pages, and displaying an
+## appropriate copyright notice / icon. GNU Free Documentation
+## License and Creative Commons licenses are supported so far.
+$wgRightsPage = ""; # Set to the title of a wiki page that describes your license/copyright
+$wgRightsUrl = "";
+$wgRightsText = "";
+$wgRightsIcon = "";
+
+# Path to the GNU diff3 utility. Used for conflict resolution.
+$wgDiff3 = "";
+
+# The following permissions were set based on your choice in the installer
+$wgGroupPermissions['*']['edit'] = false;
+$wgGroupPermissions['user']['edit'] = true;
+$wgGroupPermissions['sysop']['edit'] = true;
+
+# The default 'move' permission is set to True for every registered authenticated user, we want only sysops to allow move files and pages
+$wgGroupPermissions['user']['move'] = true;
+$wgGroupPermissions['sysop']['move'] = true;
+
+
+# Allow bots to delete pages
+$wgGroupPermissions['bot']['delete'] = true;
+$wgGroupPermissions['bot']['deletedhistory'] = true; // optional
+
+# In order to be at the 'autocomfirmed' group 'משתמשים ותיקים', we want any user to be registered for 2 weeks and have at least 3 edits
+$wgAutoConfirmAge = 86400 * 14;   // 14 days
+$wgAutoConfirmCount = 3;
+
+$wgEmailConfirmToEdit = true;
+
+# Enable images lazy loading
+$wgNativeImageLazyLoading = true;
+
+## Default skin: you can change the default skin. Use the internal symbolic
+## names, ie 'vector', 'monobook':
+$wgDefaultSkin = "Metrolook";
+
+# Enabled skins.
+# The following skins were automatically enabled:
+wfLoadSkin('Metrolook');
+
+
+// For debugging, dont remove this! just comment out.
+// $wgDebugLogFile = "$IP/MyLogs/debug-{$wgDBname}.log";
+# $wgDBerrorLog — set in LocalSettings.env.*.php
+# $wgResourceLoaderDebug — set in LocalSettings.env.*.php
+
+
+# OutputPageBeforeHTML Hook to add tags on head
+$wgHooks['BeforePageDisplay'][] = function ($out, &$text) {
+	$out->addHeadItem('Assistant-font', '<link rel="preconnect" href="https://fonts.googleapis.com">');
+	$out->addHeadItem('Assistant-font', '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>');
+	$out->addHeadItem('Assistant-font', '<link href="https://fonts.googleapis.com/css2?family=Assistant:wght@200..800&display=swap" rel="stylesheet">');
+	$out->addHeadItem('font-awsome', '<link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.5.2/css/all.css" crossorigin="anonymous">');
+	return true;
+};
+
+# Php debugging:
+// error_reporting( -1 );
+// ini_set( 'display_errors', 1 );
+
+# $wgDebugLogGroups — set in LocalSettings.env.*.php
+
+
+# $wgShowDBErrorBacktrace — set in LocalSettings.env.*.php
+
+# MaccabiPedia special configurations:
+# $wgHiddenPrefs = array(0 => 'language', 1 => 'skin'); 		# Hide Languages and Skins from user's selection
+# $wgJobRunRate — set in LocalSettings.env.*.php  # https://www.mediawiki.org/wiki/Manual:$wgJobRunRate
+$wgCountCategorizedImagesAsUsed = true;				 		# Considers categorized images as used (מיוחד:קבצים_שאינם_בשימוש)
+$wgExternalLinkTarget = '_blank'; 							# Opens External links in new tab
+$wgFavicon = "/favicon.ico"; 								# Enable Favicon
+$wgAppleTouchIcon = "/favicon.ico"; 						# Enable Favicon for Apple Devices
+$wgAllowSiteCSSOnRestrictedPages = 1; 						# Enable CSS on Login Page
+$wgExpensiveParserFunctionLimit = 10000; 						# Enable 10000 Expensive Parser Function Limit
+
+
+$wgMaxArticleSize = 8192;  // This is to avoid the "<!-- WARNING: template omitted, post-expand include size too large -->" msg (caused atleast in שרן ייני page).
+
+$wgMaxImageArea = 2.5e7;  # Allow to show preview of image up to 36 million pixels or 6000×6000, https://www.mediawiki.org/wiki/Manual:$wgMaxImageArea
+$wgMaxShellMemory = 512000;  # Use up to 512MIB of virtual memory, https://www.mediawiki.org/wiki/Manual:$wgMaxShellMemory
+$wgMemoryLimit = 268435456; # https://www.mediawiki.org/wiki/Manual:$wgMemoryLimit
+
+
+define("NS_שיר", 3000); // This MUST be even.
+define("NS_שיחת_שיר", 3001);
+define("NS_כדורעף", 3001);
+define("NS_שיחת_כדורעף", 3002);
+define("NS_כדורסל", 3003);
+define("NS_שיחת_כדורסל", 3004);
+define("NS_כדורגל", 3010);
+define("NS_שיחת_כדורגל", 3011);
+define("NS_כדוריד", 3020);
+define("NS_שיחת_כדוריד", 3021);
+
+$wgExtraNamespaces[NS_שיר] = "שיר";
+$wgExtraNamespaces[NS_שיחת_שיר] = "שיחת_שיר";
+$wgExtraNamespaces[NS_כדורעף] = "כדורעף";
+$wgExtraNamespaces[NS_שיחת_כדורעף] = "שיחת_כדורעף";
+$wgExtraNamespaces[NS_כדורסל] = "כדורסל";
+$wgExtraNamespaces[NS_שיחת_כדורסל] = "שיחת_כדורסל";
+$wgExtraNamespaces[NS_כדורגל] = "כדורגל";
+$wgExtraNamespaces[NS_שיחת_כדורגל] = "שיחת_כדורגל";
+$wgExtraNamespaces[NS_כדוריד] = "כדוריד";
+$wgExtraNamespaces[NS_שיחת_כדוריד] = "שיחת_כדוריד";
+
+// Add these namespaces to be shown as default when searching on maccabipedia - without choosing "all" section in the search results)
+$wgNamespacesToBeSearchedDefault[NS_שיר] = true;
+$wgNamespacesToBeSearchedDefault[NS_שיחת_שיר] = true;
+$wgNamespacesToBeSearchedDefault[NS_כדורעף] = true;
+$wgNamespacesToBeSearchedDefault[NS_שיחת_כדורעף] = true;
+$wgNamespacesToBeSearchedDefault[NS_כדורסל] = true;
+$wgNamespacesToBeSearchedDefault[NS_שיחת_כדורסל] = true;
+$wgNamespacesToBeSearchedDefault[NS_כדורגל] = true;
+$wgNamespacesToBeSearchedDefault[NS_שיחת_כדורגל] = true;
+$wgNamespacesToBeSearchedDefault[NS_כדוריד] = true;
+$wgNamespacesToBeSearchedDefault[NS_שיחת_כדוריד] = true;
+
+
+
+require_once "$IP/extensions/NumberFormat/NumberFormat.php"; 		# Number Format ( {{#number_format:}} ) [ https://www.mediawiki.org/wiki/Extension:NumberFormat ]
+
+// wfLoadExtension( 'HidePrefix' ); # Hide Prefix {Namespaces) from links https://www.mediawiki.org/wiki/Extension:HidePrefix
+wfLoadExtension('Loops'); # Loops ( {{#loop:}} ) https://www.mediawiki.org/wiki/Extension:Loops
+$egLoopsCountLimit = -1;
+
+wfLoadExtension('Arrays');                    # Arrays https://www.mediawiki.org/wiki/Extension:Arrays
+wfLoadExtension('AdminLinks');				# Admin Links (מיוחד: קישורי מפעיל) [ https://www.mediawiki.org/wiki/Extension:Admin_Link
+wfLoadExtension('AutoCreateCategoryPages'); 	# Auto Create Category Pages https://www.mediawiki.org/wiki/Extension:Auto_Create_Category_Pages
+wfLoadExtension('MixedNamespaceSearchSuggestions'); # https://www.mediawiki.org/wiki/Extension:MixedNamespaceSearchSuggestions
+wfLoadExtension('DynamicPageList3');			# https://www.mediawiki.org/wiki/Extension:DynamicPageList3
+
+wfLoadExtension('EmbedVideo'); 				# Embed Video ( {{#ev:}} ) https://www.mediawiki.org/wiki/Extension:EmbedVideo
+// Remove the need to approve before each video is being rendered (there's a play button anyway)
+$wgEmbedVideoRequireConsent = false;
+
+wfLoadExtension('LinkSuggest'); 				# Link Suggests for editors https://www.mediawiki.org/wiki/Extension:LinkSuggest 
+wfLoadExtension('SimpleBatchUpload'); 		# Upload Batch of files (מיוחד:BatchUpload) https://www.mediawiki.org/wiki/Extension:SimpleBatchUpload
+wfLoadExtension('Variables'); 				# https://www.mediawiki.org/wiki/Extension:Variables
+wfLoadExtension('TemplateSandbox'); // https://www.mediawiki.org/wiki/Extension:TemplateSandbox
+wfLoadExtension('DebugTemplates'); // https://www.mediawiki.org/wiki/Extension:DebugTemplates
+wfLoadExtension('LastUserLogin'); //https://www.mediawiki.org/wiki/Extension:LastUserLogin
+wfLoadExtension('JSBreadCrumbs');  // https://www.mediawiki.org/wiki/Extension:JSBreadCrumbs
+
+wfLoadExtension('WikiSEO'); // https://www.mediawiki.org/wiki/Extension:WikiSEO, need to transform our data from 1.x.x to 2.x.x (check the extension link)
+$wgWikiSeoDefaultImage = 'File:Maccabipedia logo.png';
+$wgTwitterSiteHandle = '@maccabipedia';
+
+// Welcome any new user with our default msg
+wfLoadExtension('NewUserMessage');  //https://www.mediawiki.org/wiki/Extension:NewUserMessage
+
+wfLoadExtension('ReplaceSet'); 				# https://www.mediawiki.org/wiki/Extension:ReplaceSet, a bit old - worth to replace, {{#replaceset:}}
+$egReplaceSetCallLimit = 5000;  # Change the maximum ReplaceSet usage in one page (https://www.mediawiki.org/wiki/Extension:ReplaceSet)
+$egReplaceSetPregLimit = 5000;  # Change the maximum ReplaceSet usage in one page (https://www.mediawiki.org/wiki/Extension:ReplaceSet)
+
+wfLoadExtension('PageForms'); // https://www.mediawiki.org/wiki/Extension:Page_Forms
+$wgPageFormsSimpleUpload = true;
+
+// Built in:
+wfLoadExtension('VisualEditor'); // https://www.mediawiki.org/wiki/Extension:VisualEditor
+wfLoadExtension('Nuke'); // https://www.mediawiki.org/wiki/Extension:Nuke
+wfLoadExtension('ReplaceText');
+wfLoadExtension('Renameuser');
+wfLoadExtension('Poem');
+wfLoadExtension('MultimediaViewer');
+wfLoadExtension('PdfHandler');
+wfLoadExtension('CodeEditor');
+wfLoadExtension('ConfirmEdit');
+wfLoadExtension('CategoryTree');
+wfLoadExtension('Cite');
+wfLoadExtension('CiteThisPage');
+//wfLoadExtension( 'DeleteBatch' );
+
+
+wfLoadExtension('WikiEditor'); # Enable WikiEditor  (גרסא ישנה של העורך, היות שבגרסאות החדשות הוסר טאב "שינויים אחרונים")
+$wgDefaultUserOptions['usebetatoolbar'] = 1; # Enables use of WikiEditor by default but still allows users to disable it in preferences
+$wgDefaultUserOptions['usebetatoolbar-cgd'] = 1; # Enables link and table wizards by default but still allows users to disable them in preferences
+$wgDefaultUserOptions['wikieditor-preview'] = 1; # Enables the Preview and Changes tabs
+$wgDefaultUserOptions['wikieditor-publish'] = 0; # Displays the Publish and Cancel buttons on the top right side
+
+wfLoadExtension('ParserFunctions'); # Enable Parser Functions [ https://www.mediawiki.org/wiki/Extension:ParserFunctions ]
+$wgPFEnableStringFunctions = true; # Allows to activate the integrated string function functionality
+$wgPFStringLengthLimit = 10000; # Set max StringFunctions limit to be 10k
+$wgStringFunctionsLimitReplace = 10000;
+$wgStringFunctionsLimitSearch = 10000;
+
+// wfLoadExtension('WhosOnline');  //https://www.mediawiki.org/wiki/Extension:WhosOnline due to upgrade
+$wgWhosOnlineShowAnons = false;
+
+wfLoadExtension('Maintenance'); // https://www.mediawiki.org/wiki/Extension:Maintenance
+$wgGroupPermissions['sysop']['maintenance'] = true;
+
+wfLoadExtension('SecureHTML');				#SecureHTML [https://www.mediawiki.org/wiki/Extension:Secure_HTML]
+# $wgSecureHTMLSecrets — set in LocalSettings.env.*.php
+
+wfLoadExtension('Scribunto');
+$wgScribuntoDefaultEngine = 'luastandalone';
+
+require_once "$IP/extensions/UserFunctions/UserFunctions.php"; # User Functions ( {{#ifsysop:}} ) [ https://www.mediawiki.org/wiki/Extension:UserFunctions ]
+$wgUFAllowedNamespaces = array_fill(0, 200, true);
+
+
+# $wgShowSQLErrors — set in LocalSettings.env.*.php
+# $wgShowExceptionDetails — set in LocalSettings.env.*.php
+$wgCargoMaxQueryLimit = 50000;
+$wgCargoAllowedSQLFunctions[] = array('REPLACE', 'COALESCE', 'IF', 'DATE_FORMAT', 'TRIM', 'DISTINCT', 'DAYOFWEEK', 'IFNULL');  # Needed for the Tifo template
+wfLoadExtension('Cargo');						# Cargo https://www.mediawiki.org/wiki/Extension:Cargo
+
+// Not sure if works:
+// wfLoadExtension( 'MagicNoCache' ); // https://www.mediawiki.org/wiki/Extension:MagicNoCache
+
+// Does not work with the auto-completion of the categories
+wfLoadExtension('CodeMirror');  // https://www.mediawiki.org/wiki/Extension:CodeMirror
+$wgDefaultUserOptions['usecodemirror'] = 1;
+
+// https://www.mediawiki.org/wiki/Extension:ContactPage
+wfLoadExtension('ContactPage');
+$wgContactConfig['default'] = [
+	'RecipientUser' => 'Kosh', // Must be the name of a valid account which also has a verified e-mail-address added to it.
+	'SenderName' => 'Contact Form on ' . $wgSitename, // "Contact Form on" needs to be translated
+	'SenderEmail' => null, // Defaults to $wgPasswordSender, may be changed as required
+	'RequireDetails' => true, // Either "true" or "false" as required
+	'IncludeIP' => true, // Either "true" or "false" as required
+	'MustBeLoggedIn' => false, // Check if the user is logged in before rendering the form. Either "true" or "false" as required
+	'AdditionalFields' => [
+		'Text' => [
+			'label-message' => 'emailmessage',
+			'type' => 'textarea',
+			'rows' => 20,
+			'required' => true,  // Either "true" or "false" as required
+		],
+	],
+	// Added in MW 1.26
+	'DisplayFormat' => 'table',  // See HTMLForm documentation for available values.
+	'RLModules' => [],  // Resource loader modules to add to the form display page.
+	'RLStyleModules' => []  // Resource loader CSS modules to add to the form display page.
+];
+
+
+
+$wgDplSettings['maxResultCount'] = 15000;  # Allow unlimited results on dpl, We might have some old queries that we dont limit the count for them, so we have to write here a number that will be bigger than any category we have (which is probably "Category:Games")
+# Dont use allowUnlimitedResults, this will prevent us from using "count" parametre in the queries
+
+$wgReplaceTextResultsLimit = 1000;  # Change the default max pages of replace text (250) to something we can work with (replace in all games pages)
+
+
+wfLoadExtension('TabberNeue'); // https://www.mediawiki.org/wiki/Extension:TabberNeue
+$wgTabberNeueUpdateLocationOnTabChange = true;
+$wgTabberNeueEnableAnimation = false;
+$wgTabberNeueParseTabName = true;
+
+#wfLoadExtension('GoogleRichCards'); //https://www.mediawiki.org/wiki/Extension:GoogleRichCards
+// Enable annotations for articles
+#$wgGoogleRichCardsAnnotateArticles = true;
+// Enable annotations for events
+#$wgGoogleRichCardsAnnotateEvents = true;
+// Enable WebSite annotations
+#$wgGoogleRichCardsAnnotateWebSite = true;
+
+
+wfLoadExtension('GTag');
+# $wgGTagAnalyticsId — set in LocalSettings.env.*.php
+// require_once "$IP/extensions/googleAnalytics/googleAnalytics.php"; # https://www.mediawiki.org/wiki/Extension:Google_Analytics_Integration
+// $wgGoogleAnalyticsAccount = 'UA-123078340-2';  # MaccabiPedi
+
+
+$wgResourceModules['maccabipedia.customizations'] = array(
+	'styles' => ["slick/slick.less", "slick/slick-theme.less"],
+	'scripts' => ["slick/slick.min.js", "canvasjs/jquery.canvasjs.min.js"],
+	'dependencies' => ['jquery'],
+	'localBasePath' => "$IP/customizations/",
+	'remoteBasePath' => "$wgScriptPath/customizations/",
+	'position' => 'top'
+);
+
+$wgResourceLoaderMaxage = ['versioned' => 31536000, 'unversioned' => 86400];
+
+$wgHooks['BeforePageDisplay'][] = function (&$out) {
+	$out->addModules('ext.customScripts');
+};
+
+wfLoadExtension('RegexFunctions');
+
+function efCustomBeforePageDisplay(&$out, &$skin)
+{
+	$out->addModules(array('maccabipedia.customizations'));
+}
+
+$wgHooks['BeforePageDisplay'][] = 'efCustomBeforePageDisplay';

--- a/infra/local-wiki/prod-upload/README.md
+++ b/infra/local-wiki/prod-upload/README.md
@@ -1,0 +1,40 @@
+# prod-upload — three files to FTP into the prod wiki root
+
+Upload **all three** of these files into the prod web root (the directory
+that currently contains the live `LocalSettings.php`). Replace the existing
+`LocalSettings.php` with the one in this folder.
+
+| Local path | Upload as | Tracked in git? |
+|---|---|---|
+| `LocalSettings.php` | `LocalSettings.php` (overwrites the monolith) | yes |
+| `LocalSettings.shared.php` | `LocalSettings.shared.php` (new file) | yes |
+| `LocalSettings.env.prod.php` | `LocalSettings.env.prod.php` (new file) | **no** — gitignored, contains real DB password / SecretKey / UpgradeKey / SecureHTML secret |
+
+After uploading, browse `https://www.maccabipedia.co.il/` once and confirm
+the homepage renders. If anything looks off, FTP the backup of the original
+`LocalSettings.php` back over the new stub — the other two files become
+inert because nothing requires them.
+
+## Behavioral notes
+
+The split is byte-equivalent to the prior monolithic LocalSettings.php
+**except**:
+
+- `$wgFavicon` and `$wgAppleTouchIcon` switched from absolute
+  (`https://www.maccabipedia.co.il/favicon.ico`) to relative (`/favicon.ico`).
+  Both still resolve to the same file on prod.
+
+Everything else — extensions, namespaces, group permissions, hooks, Cargo
+config, ContactPage config, namespace defines — is unchanged. The
+`$wgDebugLogGroups` paths intentionally stay single-quoted (literal `$IP`
+and `{$wgDBname}`) to match prod's existing log path behavior.
+
+## Source of truth
+
+This folder is the canonical home for `LocalSettings.shared.php` and
+`LocalSettings.env.prod.php`. The local docker stack at
+`infra/local-wiki/docker-compose.yml` bind-mounts `LocalSettings.shared.php`
+from here, so any edit lands in both prod and dev runs after the next
+docker reload. No copying or syncing required.
+
+`LocalSettings.env.prod.php` is gitignored — never committed.

--- a/infra/local-wiki/scripts/setup-host.sh
+++ b/infra/local-wiki/scripts/setup-host.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Install host prerequisites for the local MaccabiPedia docker stack on a
+# fresh Ubuntu / Debian / WSL Ubuntu machine. Idempotent — safe to re-run.
+#
+# Installs: docker.io, docker-compose-v2, lftp. Adds the invoking user to
+# the `docker` group. Starts and enables the docker daemon.
+#
+# macOS / Windows: use Docker Desktop (with WSL 2 integration on Windows)
+# instead — this script targets apt-based Linux only.
+
+set -euo pipefail
+
+if ! command -v apt-get >/dev/null 2>&1; then
+    echo "ERROR: this script requires apt (Debian/Ubuntu). On macOS/Windows install Docker Desktop manually." >&2
+    exit 1
+fi
+
+if [ "$(id -u)" -eq 0 ]; then
+    echo "ERROR: run this as a regular user with sudo, not as root." >&2
+    exit 1
+fi
+
+echo "==> Installing docker.io, docker-compose-v2, lftp"
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+    docker.io \
+    docker-compose-v2 \
+    lftp
+
+echo "==> Ensuring docker daemon is enabled and running"
+sudo systemctl enable --now docker
+
+TARGET_USER="${SUDO_USER:-$USER}"
+if id -nG "$TARGET_USER" | tr ' ' '\n' | grep -qx docker; then
+    echo "==> $TARGET_USER is already in the docker group"
+else
+    echo "==> Adding $TARGET_USER to the docker group"
+    sudo usermod -aG docker "$TARGET_USER"
+    echo
+    echo "NOTE: You must start a new shell (or run 'newgrp docker') before"
+    echo "      'docker' works without sudo for user $TARGET_USER."
+fi
+
+echo
+echo "Host prerequisites installed. Versions:"
+docker --version
+docker compose version
+lftp --version | head -n 1

--- a/infra/local-wiki/scripts/sync-from-prod.sh
+++ b/infra/local-wiki/scripts/sync-from-prod.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Pull selected files/directories from the production MaccabiPedia FTP server
+# into the (gitignored) infra/local-wiki/synced/ directory.
+#
+# Security model:
+#   - Only the named operations below are supported — no arbitrary paths.
+#   - Download-only. lftp mirror is invoked without -R; no `put`/`rm`/reverse
+#     sync is available through this script. A scoped read-only FTP account
+#     is recommended but not enforced here.
+#   - Credentials come from env vars; never hardcoded, never logged.
+#   - Every invocation appends a timestamped line to SYNC_LOG.
+#
+# Required environment variables:
+#   MACCABIPEDIA_FTP_HOST        — FTP hostname (e.g. ftp.maccabipedia.co.il)
+#   MACCABIPEDIA_FTP_USER        — FTP username
+#   MACCABIPEDIA_FTP_PASS        — FTP password
+#   MACCABIPEDIA_FTP_REMOTE_ROOT — absolute path of the MediaWiki webroot on
+#                                  the FTP server (e.g. /public_html)
+#
+# Optional:
+#   MACCABIPEDIA_FTP_REQUIRE_TLS=1   — fail unless the control channel is TLS
+#
+# Usage:
+#   ./sync-from-prod.sh <op>
+#
+# Allowed <op> values:
+#   skins            — mirror <root>/skins/           → synced/skins/
+#   extensions       — mirror <root>/extensions/      → synced/extensions/
+#   localsettings    — fetch   <root>/LocalSettings.php
+#                      → synced/LocalSettings.prod-snapshot.php
+#   logo-assets      — mirror <root>/resources/assets/ → synced/resources/assets/
+#   versions         — list remote directory names under the webroot for audit
+#                      (no downloads; prints remote listing only)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_WIKI_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SYNCED_DIR="${LOCAL_WIKI_DIR}/synced"
+
+REPO_ROOT="$(cd "${LOCAL_WIKI_DIR}/../.." && pwd)"
+SYNC_LOG="${REPO_ROOT}/.claude/tmp/ftp-sync.log"
+
+# Auto-load local .env if present. It's gitignored; intended for FTP creds.
+# Only MACCABIPEDIA_FTP_* vars are honored downstream, other vars in the file
+# will be set but not used by this script.
+ENV_FILE="${LOCAL_WIKI_DIR}/.env"
+if [ -f "$ENV_FILE" ]; then
+    echo "==> sourcing ${ENV_FILE}"
+    set -a
+    # shellcheck disable=SC1090
+    . "$ENV_FILE"
+    set +a
+fi
+
+usage() {
+    sed -n '2,35p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+require_env() {
+    local missing=()
+    for var in "$@"; do
+        if [ -z "${!var-}" ]; then
+            missing+=("$var")
+        fi
+    done
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "ERROR: missing required env var(s): ${missing[*]}" >&2
+        exit 1
+    fi
+}
+
+log_event() {
+    mkdir -p "$(dirname "$SYNC_LOG")"
+    printf '%s  %s  remote=%s  local=%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        "$1" "$2" "${3:-}" \
+        >> "$SYNC_LOG"
+}
+
+run_lftp() {
+    local script="$1"
+    # Shared hosts often present self-signed / untrusted TLS certs. Default is
+    # TLS encryption *without* strict cert verification — encrypts password on
+    # the wire, accepts untrusted cert. Set MACCABIPEDIA_FTP_TLS_VERIFY=1 to
+    # require a system-trusted cert. Set MACCABIPEDIA_FTP_REQUIRE_TLS=1 to
+    # refuse the connection entirely if the server does not offer TLS.
+    local tls_line="set ftp:ssl-allow yes; set ftp:ssl-force no; set ssl:verify-certificate no;"
+    if [ "${MACCABIPEDIA_FTP_REQUIRE_TLS:-0}" = "1" ]; then
+        tls_line="set ftp:ssl-allow yes; set ftp:ssl-force yes; set ssl:verify-certificate no;"
+    fi
+    if [ "${MACCABIPEDIA_FTP_TLS_VERIFY:-0}" = "1" ]; then
+        tls_line="${tls_line//verify-certificate no/verify-certificate yes}"
+    fi
+    lftp -u "${MACCABIPEDIA_FTP_USER},${MACCABIPEDIA_FTP_PASS}" \
+         "${MACCABIPEDIA_FTP_HOST}" \
+         -e "${tls_line} set net:max-retries 3; set net:timeout 20; ${script}; bye"
+}
+
+op_mirror_dir() {
+    local remote_sub="$1"
+    local local_sub="$2"
+    local remote="${MACCABIPEDIA_FTP_REMOTE_ROOT%/}/${remote_sub}"
+    local local_dir="${SYNCED_DIR}/${local_sub}"
+
+    mkdir -p "$local_dir"
+    echo "==> lftp mirror  ${remote}  ->  ${local_dir}"
+    run_lftp "mirror --verbose --only-missing --parallel=4 '${remote}' '${local_dir}'"
+    log_event "mirror" "${remote}" "${local_dir}"
+}
+
+op_localsettings() {
+    local remote="${MACCABIPEDIA_FTP_REMOTE_ROOT%/}/LocalSettings.php"
+    local local_file="${SYNCED_DIR}/LocalSettings.prod-snapshot.php"
+
+    mkdir -p "${SYNCED_DIR}"
+    echo "==> lftp get  ${remote}  ->  ${local_file}"
+    run_lftp "get '${remote}' -o '${local_file}'"
+    log_event "get" "${remote}" "${local_file}"
+    echo "   snapshot saved. Scrub secrets before committing anything derived from it."
+}
+
+op_versions() {
+    local remote="${MACCABIPEDIA_FTP_REMOTE_ROOT%/}"
+    echo "==> lftp cls -l  ${remote}"
+    run_lftp "cls -l '${remote}'"
+    log_event "list" "${remote}" ""
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+op="$1"
+
+require_env MACCABIPEDIA_FTP_HOST MACCABIPEDIA_FTP_USER MACCABIPEDIA_FTP_PASS MACCABIPEDIA_FTP_REMOTE_ROOT
+
+case "$op" in
+    skins)         op_mirror_dir "skins"             "skins" ;;
+    extensions)    op_mirror_dir "extensions"        "extensions" ;;
+    logo-assets)   op_mirror_dir "resources/assets"  "resources/assets" ;;
+    localsettings) op_localsettings ;;
+    versions)      op_versions ;;
+    -h|--help|help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "ERROR: unknown op '$op'" >&2
+        echo >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
+echo "done."


### PR DESCRIPTION
## Summary
- Replaces the override-block trick in `entrypoint.sh` with the proper multi-env MediaWiki pattern: a 5-line `LocalSettings.php` stub `require_once`s first an env-specific file (prod / local) and then a shared site-wide file.
- `prod-upload/LocalSettings.shared.php` is byte-equivalent to the prior monolithic prod `LocalSettings.php` **except** `$wgFavicon` / `$wgAppleTouchIcon` switched from absolute to relative URLs so the same file works locally and on prod.
- **Prod is already running this split** (uploaded manually via FTP before this PR). This PR purely codifies what is already deployed.

## What changed

Committed under `infra/local-wiki/prod-upload/`:
- `LocalSettings.php` — 5-line prod stub (`env.prod.php` → `shared.php`)
- `LocalSettings.shared.php` — site-wide config (extensions, skins, namespaces, hooks, Cargo, ContactPage, TabberNeue…)
- `README.md` — FTP upload instructions
- `LocalSettings.env.prod.php` is **gitignored** (contains real DB password, SecretKey, UpgradeKey, SecureHTML secret)

Dev side under `infra/local-wiki/`:
- `LocalSettings.stub.php` — dev bootstrap stub
- `LocalSettings.env.local.php` — dev env values (CACHE_NONE, mariadb host from `MW_DB_*` env, verbose errors, empty SecureHTML + GTag)

`entrypoint.sh` simplified:
- Runs `install.php` once, tracked via `/generated/.installed` marker; output discarded to `/tmp`.
- Copies the stub to `/var/www/html/LocalSettings.php` every boot as a real file (not symlink). Symlinking would break `__DIR__`, which must resolve to `/var/www/html/` where the env + shared files are bind-mounted as siblings.

## Test plan
- [x] Fresh `docker compose down -v` → `up -d --build` boots cleanly; `http://localhost:8080/` returns 200 with title `מכביפדיה` and `skin-metrolook`.
- [x] Container restart does NOT re-run `install.php` (marker file works; only `update.php --quick` runs on second boot).
- [x] Inside container: all four files (`LocalSettings.php`, `LocalSettings.env.local.php`, `LocalSettings.shared.php`, `LocalSettings.stub.php`) are siblings in `/var/www/html/`; `LocalSettings.php` is a regular file, not a symlink.
- [x] Staged diff grepped for the four prod secrets — none leaked.
- [x] `uv run pytest` — 381 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)