### PR TITLE
fix(football): switch league-table source to playoff stages

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/football/update_league_table.py
+++ b/packages/maccabipediabot/src/maccabipediabot/football/update_league_table.py
@@ -26,11 +26,12 @@ OPPONENTS_NAMES_TO_UNICODE = {"FC Ashdod": "\u05de.\u05e1. \u05d0\u05e9\u05d3\u0
                               "Ironi Tiberias": "עירוני טבריה", "Hapoel Ironi Kiryat Shmona": "עירוני קריית שמונה"}
 
 LINKS_TO_FETCH_LEAGUE_TABLE_FROM = [
-    # Links for probably playoff stages:
-    #"https://prod-public-api.livescore.com/v1/api/app/stage/soccer/israel/premier-league-championship-group/3",
-    #"https://prod-public-api.livescore.com/v1/api/app/stage/soccer/israel/premier-league-relegation-group/3",
+    # Playoff stages (top 6 + bottom 8). Swap with the regular-season URL below
+    # at the start of each season, then back once playoffs begin.
+    "https://prod-public-api.livescore.com/v1/api/app/stage/soccer/israel/premier-league-championship-group/3",
+    "https://prod-public-api.livescore.com/v1/api/app/stage/soccer/israel/premier-league-relegation-group/3",
 
-    "https://prod-public-api.livescore.com/v1/api/app/stage/soccer/israel/premier-league/3?locale=en&MD=1"
+    #"https://prod-public-api.livescore.com/v1/api/app/stage/soccer/israel/premier-league/3?locale=en&MD=1"
 ]
 
 from maccabipediabot.common.logging_setup import setup_logging


### PR DESCRIPTION
## Summary
- Israeli Premier League regular season ended at round 26; livescore's `premier-league/3` stage is frozen and won't advance further.
- Switch the active source to the two playoff stages: `premier-league-championship-group/3` (top 6) and `premier-league-relegation-group/3` (bottom 8). Verified both return current round-27/28 data with correct points and games-played.
- Same toggle that was applied last season (commits 8710984 + 1b3475e on 2025-03-22).

## Test plan
- [x] `uv run pytest packages/maccabipediabot` — 204 passed
- [x] Probed all three URLs against the live livescore API; playoff endpoints return updated standings, regular-season endpoint still shows pld=26 for everyone
- [ ] After merge, manually trigger `Update league table status` workflow and verify [[תבנית:טבלת ליגת כדורגל 2025/26]] reflects new standings

🤖 Generated with [Claude Code](https://claude.com/claude-code)