### PR TITLE
chore(dev): use maccabi/maccabi for local wiki admin

### DIFF
--- a/infra/local-wiki/README.md
+++ b/infra/local-wiki/README.md
@@ -39,7 +39,7 @@ docker compose up -d --build
 Open http://localhost:8080 — you'll see the `מכביפדיה` site with the real
 Metrolook skin, prod's extension set, and the seeded pages rendering.
 
-Admin user: `admin` / `devadminpass` (from `docker-compose.yml`; local-only).
+Admin user: `maccabi` / `maccabi` (from `docker-compose.yml`; local-only).
 
 ## Adjusting the seed set
 

--- a/infra/local-wiki/docker-compose.yml
+++ b/infra/local-wiki/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       MW_DB_USER: mw
       MW_DB_PASSWORD: devpass
       MW_DB_PREFIX: "MPMW_"
-      MW_ADMIN_USER: admin
-      MW_ADMIN_PASSWORD: devadminpass
+      MW_ADMIN_USER: maccabi
+      MW_ADMIN_PASSWORD: maccabi
       MW_SITE_NAME: "MaccabiPedia Dev"
       MW_SITE_SERVER: "http://localhost:8080"
       MW_SITE_LANG: "he"


### PR DESCRIPTION
## Summary
- Renames the local docker stack's admin user from `admin` / `devadminpass` to `maccabi` / `maccabi` (`infra/local-wiki/docker-compose.yml`).
- Updates the credential mention in `infra/local-wiki/README.md` to match.

Closes the Trello card [#536 — Local dev admin: change credentials to maccabi / maccabi](https://trello.com/c/sCO0WfyG).

Local-only, no security impact.

## Test plan
- [ ] `docker compose down -v && docker compose up -d --build` in `infra/local-wiki/` (volume wipe is required — existing `mw_db` still holds the old `admin` user)
- [ ] Log in to http://localhost:8080 with `maccabi` / `maccabi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)