### PR TITLE
feat(dev): copy infra/local-wiki/.env into new worktrees

### DIFF
--- a/.claude/hooks/create-worktree.sh
+++ b/.claude/hooks/create-worktree.sh
@@ -43,6 +43,14 @@ if [ -f "$CAL_ENV" ]; then
     cp "$CAL_ENV" "${WT_DIR}/packages/maccabipediabot/src/maccabipediabot/calendar/.env"
 fi
 
+# Copy local-wiki .env (gitignored, has prod FTP credentials)
+LW_ENV="${REPO_ROOT}/infra/local-wiki/.env"
+if [ -f "$LW_ENV" ]; then
+    mkdir -p "${WT_DIR}/infra/local-wiki"
+    cp "$LW_ENV" "${WT_DIR}/infra/local-wiki/.env"
+    chmod 600 "${WT_DIR}/infra/local-wiki/.env"
+fi
+
 # Create independent venv with packages (uv is ~10x faster than pip)
 if [ ! -e "${WT_DIR}/.venv" ]; then
     uv sync --directory "${WT_DIR}" >&2


### PR DESCRIPTION
## Summary
- `.claude/hooks/create-worktree.sh` now copies `infra/local-wiki/.env` from `REPO_ROOT` into the new worktree (mode 600), mirroring the existing calendar `.env` block.
- Without it, a fresh worktree can't run `infra/local-wiki/scripts/sync-from-prod.sh` and the local Docker stack can't be repopulated when `synced/extensions/` is missing.

Trello: https://trello.com/c/dMO1FPCj

## Test plan
- [x] Bash syntax check (`bash -n`)
- [x] Simulated the new block against a worktree that has the source `.env` — file copied, mode 600, contents matched
- [ ] Verified end-to-end by creating a fresh worktree once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)