### PR TITLE
fix(basketball): preserve jersey #0 instead of writing מספר=None

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/basketball/basketball_game.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/basketball_game.py
@@ -4,6 +4,14 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+
+def _blank_if_none(value: Optional[int]) -> str:
+    """Render an Optional[int] as a wiki-template value: int → str, None → ''.
+    Prevents the literal string 'None' from leaking into the wiki when an
+    upstream crawler couldn't determine a stat."""
+    return "" if value is None else str(value)
+
+
 class PlayerSummary(BaseModel):
     name: str
     number: Optional[int] = None
@@ -34,11 +42,10 @@ class PlayerSummary(BaseModel):
         # every other Optional[int] goes through `_blank_if_none` so a missing value
         # never leaks the string "None" into the wiki (e.g. jersey-less player → "מספר=").
         starting_five_str = {True: "כן", False: "לא"}.get(self.is_starting_five, "")
-        b = _blank_if_none
         inner = " |".join([
             f"שם={self.name}",
-            f"מספר={b(self.number)}",
-            f"דקות={b(self.minutes_played)}",
+            f"מספר={_blank_if_none(self.number)}",
+            f"דקות={_blank_if_none(self.minutes_played)}",
             f"חמישייה={starting_five_str}",
             f"נק={self.total_points or ''}",
             f"זריקות עונשין={self.free_throws_attempts}",
@@ -47,21 +54,17 @@ class PlayerSummary(BaseModel):
             f"קליעות שתי נק={self.field_goals_scored}",
             f"זריקות שלוש נק={self.three_scores_attempts}",
             f"קליעות שלוש נק={self.three_scores_scored}",
-            f"ריבאונד הגנה={b(self.defensive_rebounds)}",
-            f"ריבאונד התקפה={b(self.offensive_rebounds)}",
-            f"פאולים={b(self.personal_total_fouls)}",
+            f"ריבאונד הגנה={_blank_if_none(self.defensive_rebounds)}",
+            f"ריבאונד התקפה={_blank_if_none(self.offensive_rebounds)}",
+            f"פאולים={_blank_if_none(self.personal_total_fouls)}",
             *(f"פאולים טכני={self.personal_technical_fouls}" if self.personal_technical_fouls is not None else []),
-            f"חטיפות={b(self.steals)}",
-            f"איבודים={b(self.turnovers)}",
-            f"אסיסטים={b(self.assists)}",
-            f"בלוקים={b(self.blocks)}",
+            f"חטיפות={_blank_if_none(self.steals)}",
+            f"איבודים={_blank_if_none(self.turnovers)}",
+            f"אסיסטים={_blank_if_none(self.assists)}",
+            f"בלוקים={_blank_if_none(self.blocks)}",
         ])
 
         return f"{{{{אירועי שחקן סל |{inner}}}}}"
-
-
-def _blank_if_none(value: Optional[int]) -> str:
-    return "" if value is None else str(value)
 
 class BasketballGame(BaseModel):
     home_team_name: str

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/basketball_game.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/basketball_game.py
@@ -30,12 +30,15 @@ class PlayerSummary(BaseModel):
     def __maccabipedia__(self) -> str:
         # Field order matches the existing wiki convention: 2pt before 3pt;
         # is_starting_five renders True→"כן", False→"לא", None→"" (unknown);
-        # total_points falsy values (0 / None) render as empty so a DNP looks like "נק=" not "נק=0".
+        # total_points falsy values (0 / None) render as empty so a DNP looks like "נק=" not "נק=0";
+        # every other Optional[int] goes through `_blank_if_none` so a missing value
+        # never leaks the string "None" into the wiki (e.g. jersey-less player → "מספר=").
         starting_five_str = {True: "כן", False: "לא"}.get(self.is_starting_five, "")
+        b = _blank_if_none
         inner = " |".join([
             f"שם={self.name}",
-            f"מספר={self.number}",
-            f"דקות={self.minutes_played}",
+            f"מספר={b(self.number)}",
+            f"דקות={b(self.minutes_played)}",
             f"חמישייה={starting_five_str}",
             f"נק={self.total_points or ''}",
             f"זריקות עונשין={self.free_throws_attempts}",
@@ -44,17 +47,21 @@ class PlayerSummary(BaseModel):
             f"קליעות שתי נק={self.field_goals_scored}",
             f"זריקות שלוש נק={self.three_scores_attempts}",
             f"קליעות שלוש נק={self.three_scores_scored}",
-            f"ריבאונד הגנה={self.defensive_rebounds}",
-            f"ריבאונד התקפה={self.offensive_rebounds}",
-            f"פאולים={self.personal_total_fouls}",
+            f"ריבאונד הגנה={b(self.defensive_rebounds)}",
+            f"ריבאונד התקפה={b(self.offensive_rebounds)}",
+            f"פאולים={b(self.personal_total_fouls)}",
             *(f"פאולים טכני={self.personal_technical_fouls}" if self.personal_technical_fouls is not None else []),
-            f"חטיפות={self.steals}",
-            f"איבודים={self.turnovers}",
-            f"אסיסטים={self.assists}",
-            f"בלוקים={self.blocks}",
+            f"חטיפות={b(self.steals)}",
+            f"איבודים={b(self.turnovers)}",
+            f"אסיסטים={b(self.assists)}",
+            f"בלוקים={b(self.blocks)}",
         ])
 
         return f"{{{{אירועי שחקן סל |{inner}}}}}"
+
+
+def _blank_if_none(value: Optional[int]) -> str:
+    return "" if value is None else str(value)
 
 class BasketballGame(BaseModel):
     home_team_name: str

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
@@ -11,7 +11,7 @@ import requests
 from aiohttp import ClientSession
 from bs4 import BeautifulSoup, Tag
 
-from maccabipediabot.basketball._crawler_utils import season_from_date
+from maccabipediabot.basketball._crawler_utils import season_from_date, to_int_or_none
 from maccabipediabot.basketball.basketball_game import BasketballGame, PlayerSummary
 from maccabipediabot.basketball.translations import (
     basket_co_il_competition_name,
@@ -242,10 +242,9 @@ def _parse_player_rows(table: Tag) -> list[PlayerSummary]:
         number_link = tds[0].select_one("a")
         name_link = tds[1].select_one("a")
         raw_name = name_link.get_text(strip=True) if name_link else ""
-        number_text = number_link.get_text(strip=True) if number_link else ""
 
         players.append(PlayerSummary(
-            number=int(number_text) if number_text.isdigit() else None,
+            number=to_int_or_none(number_link.get_text(strip=True) if number_link else None),
             name=normalize_player_name(raw_name),
             is_starting_five=tds[2].get_text(strip=True) == "*",
             minutes_played=_to_int(tds[3].get_text()),

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
@@ -242,9 +242,10 @@ def _parse_player_rows(table: Tag) -> list[PlayerSummary]:
         number_link = tds[0].select_one("a")
         name_link = tds[1].select_one("a")
         raw_name = name_link.get_text(strip=True) if name_link else ""
+        number_text = number_link.get_text(strip=True) if number_link else ""
 
         players.append(PlayerSummary(
-            number=_to_int(number_link.get_text() if number_link else None) or None,
+            number=int(number_text) if number_text.isdigit() else None,
             name=normalize_player_name(raw_name),
             is_starting_five=tds[2].get_text(strip=True) == "*",
             minutes_played=_to_int(tds[3].get_text()),

--- a/packages/maccabipediabot/tests/basketball/test_basketball_game.py
+++ b/packages/maccabipediabot/tests/basketball/test_basketball_game.py
@@ -66,6 +66,19 @@ def test_player_summary_zero_points_renders_as_empty():
     assert "|נק= |" in _make_player(total_points=0).__maccabipedia__()
 
 
+@pytest.mark.parametrize("field", [
+    "number", "minutes_played",
+    "defensive_rebounds", "offensive_rebounds", "personal_total_fouls",
+    "steals", "turnovers", "assists", "blocks",
+])
+def test_player_summary_optional_int_none_never_renders_as_literal_None(field):
+    """Catches the whole class of 'leaks Python None into the wiki' bug —
+    the originator of which was `מספר=None` for two #0-jersey players on the
+    29-04-2026 Maccabi vs Netanya page (Lundberg, Cameron Oliver)."""
+    rendered = _make_player(**{field: None}).__maccabipedia__()
+    assert "=None" not in rendered
+
+
 # ---------------------------------------------------------------------------
 # BasketballGame — home/away logic + from_raw
 # ---------------------------------------------------------------------------

--- a/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
+++ b/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
@@ -4,9 +4,11 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
+from bs4 import BeautifulSoup
 
 from maccabipediabot.basketball.basketball_game import BasketballGame
 from maccabipediabot.basketball.crawl_basket_co_il import (
+    _parse_player_rows,
     discover_games_latest_season,
     parse_game_page,
 )
@@ -38,6 +40,46 @@ def test_parse_game_page_against_real_fixture():
     )
     actual = parse_game_page(html, _partial_game())
     assert actual.model_dump() == expected.model_dump()
+
+
+def _player_row_html(jersey_link_html: str) -> str:
+    """Minimal player table: 1 header row.row + 1 player row.row + totals row.
+    The player row has 21 <td>s with the column layout _parse_player_rows expects.
+    `jersey_link_html` goes in tds[0]; pass an `<a>` to simulate a linked number,
+    or empty string to simulate no link."""
+    cells = [f"<td>{jersey_link_html}</td>"]                       # 0: number
+    cells += ['<td><a href="x">איפה לונדברג</a></td>']            # 1: name
+    cells += ['<td></td>']                                         # 2: starting *
+    cells += ['<td>10</td>']                                       # 3: minutes
+    cells += ['<td>0</td>']                                        # 4: total points
+    cells += ['<td>0/3</td>', '<td>0</td>']                        # 5,6: 2pt
+    cells += ['<td>0/3</td>', '<td>0</td>']                        # 7,8: 3pt
+    cells += ['<td>0/0</td>', '<td>0</td>']                        # 9,10: ft
+    cells += ['<td>4</td>', '<td>0</td>']                          # 11,12: rebounds
+    cells += ['<td>0</td>']                                        # 13: total rebounds (unused)
+    cells += ['<td>2</td>']                                        # 14: fouls
+    cells += ['<td>0</td>']                                        # 15: pad
+    cells += ['<td>0</td>', '<td>1</td>', '<td>0</td>', '<td>0</td>']  # 16-19: steals, to, ast, blk
+    cells += ['<td>0</td>']                                        # 20: pad to reach 21
+    return f"""
+    <table>
+      <tr class="row"><td>header</td></tr>
+      <tr class="row">{''.join(cells)}</tr>
+      <tr><td>totals</td></tr>
+    </table>
+    """
+
+
+@pytest.mark.parametrize("jersey_link_html, expected_number", [
+    ('<a href="player.asp?PlayerId=1">0</a>', 0),    # jersey #0 must stay 0, not collapse to None
+    ('<a href="player.asp?PlayerId=1">23</a>', 23),
+    ('', None),                                       # no <a> in the cell → number unknown
+])
+def test_parse_player_rows_preserves_jersey_zero(jersey_link_html, expected_number):
+    table = BeautifulSoup(_player_row_html(jersey_link_html), "html.parser").select_one("table")
+    players = _parse_player_rows(table)
+    assert len(players) == 1
+    assert players[0].number == expected_number
 
 
 def test_parse_game_page_raises_when_header_missing():

--- a/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
+++ b/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
@@ -42,13 +42,13 @@ def test_parse_game_page_against_real_fixture():
     assert actual.model_dump() == expected.model_dump()
 
 
-def _player_row_html(jersey_link_html: str) -> str:
-    """Minimal player table: 1 header row.row + 1 player row.row + totals row.
-    The player row has 21 <td>s with the column layout _parse_player_rows expects.
-    `jersey_link_html` goes in tds[0]; pass an `<a>` to simulate a linked number,
-    or empty string to simulate no link."""
-    cells = [f"<td>{jersey_link_html}</td>"]                       # 0: number
-    cells += ['<td><a href="x">איפה לונדברג</a></td>']            # 1: name
+def _player_row(cell0: str, name: str = "איפה לונדברג") -> str:
+    """One <tr class='row'> with the 21 <td>s _parse_player_rows expects.
+    `cell0` is whatever goes inside tds[0] (the number cell) — pass an `<a>...`
+    to simulate a linked number, '&nbsp;' to simulate the team-row layout, or
+    plain text to simulate a number with no surrounding link."""
+    cells = [f"<td>{cell0}</td>"]                                  # 0: number
+    cells += [f'<td><a href="x">{name}</a></td>']                  # 1: name
     cells += ['<td></td>']                                         # 2: starting *
     cells += ['<td>10</td>']                                       # 3: minutes
     cells += ['<td>0</td>']                                        # 4: total points
@@ -61,22 +61,35 @@ def _player_row_html(jersey_link_html: str) -> str:
     cells += ['<td>0</td>']                                        # 15: pad
     cells += ['<td>0</td>', '<td>1</td>', '<td>0</td>', '<td>0</td>']  # 16-19: steals, to, ast, blk
     cells += ['<td>0</td>']                                        # 20: pad to reach 21
+    return f'<tr class="row">{"".join(cells)}</tr>'
+
+
+def _player_table_html(player_row: str) -> str:
+    """Minimal table mirroring basket.co.il layout: two non-row header rows,
+    a `tr.row` "קבוצתי" team row that the parser treats as the column header,
+    the player row under test, and a `tr.row` "סה\"כ" totals row that the
+    parser drops via `[start_index:-1]`."""
     return f"""
     <table>
-      <tr class="row"><td>header</td></tr>
-      <tr class="row">{''.join(cells)}</tr>
-      <tr><td>totals</td></tr>
+      <tr class="header_row_2"><td>section header</td></tr>
+      <tr class="header_row"><td>column labels</td></tr>
+      {_player_row("&nbsp;", name="קבוצתי")}
+      {player_row}
+      {_player_row("&nbsp;", name='סה"כ')}
     </table>
     """
 
 
-@pytest.mark.parametrize("jersey_link_html, expected_number", [
+@pytest.mark.parametrize("cell0, expected_number", [
     ('<a href="player.asp?PlayerId=1">0</a>', 0),    # jersey #0 must stay 0, not collapse to None
     ('<a href="player.asp?PlayerId=1">23</a>', 23),
-    ('', None),                                       # no <a> in the cell → number unknown
+    ('<a href="player.asp?PlayerId=1">00</a>', 0),   # zero-padded — basket.co.il sometimes does this
+    ('<a href="player.asp?PlayerId=1"></a>', None),  # link present but empty text → unknown
+    ('&nbsp;', None),                                # no <a> at all → unknown
 ])
-def test_parse_player_rows_preserves_jersey_zero(jersey_link_html, expected_number):
-    table = BeautifulSoup(_player_row_html(jersey_link_html), "html.parser").select_one("table")
+def test_parse_player_rows_preserves_jersey_number(cell0, expected_number):
+    html = _player_table_html(_player_row(cell0))
+    table = BeautifulSoup(html, "html.parser").select_one("table")
     players = _parse_player_rows(table)
     assert len(players) == 1
     assert players[0].number == expected_number

--- a/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
+++ b/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
@@ -42,7 +42,7 @@ def test_parse_game_page_against_real_fixture():
     assert actual.model_dump() == expected.model_dump()
 
 
-def _player_row(cell0: str, name: str = "איפה לונדברג") -> str:
+def _player_row(cell0: str, name: str = "מיקי ברקוביץ'") -> str:
     """One <tr class='row'> with the 21 <td>s _parse_player_rows expects.
     `cell0` is whatever goes inside tds[0] (the number cell) — pass an `<a>...`
     to simulate a linked number, '&nbsp;' to simulate the team-row layout, or


### PR DESCRIPTION
## Summary

The basket.co.il parser collapses a legitimate jersey **#0** into `None`, and the template then stringifies it on the wiki as `מספר=None`.

Bug at `crawl_basket_co_il.py:247`:

```python
number=_to_int(number_link.get_text() if number_link else None) or None,
```

`_to_int("0")` returns `0`, then `0 or None` → `None`, because `0` is falsy.

Observed on [29-04-2026 מכבי תל אביב נגד אליצור עירוני נתניה](https://www.maccabipedia.co.il/%D7%9B%D7%93%D7%95%D7%A8%D7%A1%D7%9C:29-04-2026_%D7%9E%D7%9B%D7%91%D7%99_%D7%AA%D7%9C_%D7%90%D7%91%D7%99%D7%91_%D7%A0%D7%92%D7%93_%D7%90%D7%9C%D7%99%D7%A6%D7%95%D7%A8_%D7%A2%D7%99%D7%A8%D7%95%D7%A0%D7%99_%D7%A0%D7%AA%D7%A0%D7%99%D7%94_-_%D7%9C%D7%99%D7%92%D7%AA_%D7%94%D7%A2%D7%9C): both איפה לונדברג (Maccabi) and קמרון אוליבר (Netanya) wear #0 and got `מספר=None`, manually corrected by אורן המתעפץ.

## Fix

Distinguish "no `<a>` in the cell" from "the parsed number is 0":

```python
number_text = number_link.get_text(strip=True) if number_link else ""
number = int(number_text) if number_text.isdigit() else None
```

## Test plan

- [x] New parametrized test `test_parse_player_rows_preserves_jersey_zero` covers `#0`, regular `#23`, and the no-link case
- [x] Existing fixture-snapshot test still passes
- [x] `uv run pytest` — 490 passed
- [ ] Once merged: re-upload of the next basket.co.il game with a #0 player produces `מספר=0`, not `מספר=None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)