### PR TITLE
feat(dev): WSL watchdog + tinyproxy auto-restart on proxy host

### DIFF
--- a/infra/euroleague-proxy/install.sh
+++ b/infra/euroleague-proxy/install.sh
@@ -49,18 +49,36 @@ echo 'OnFailure=notify-failure@%n.service' >> /etc/systemd/system/tailscaled.ser
 systemctl daemon-reload
 systemctl enable --now tinyproxy tailscaled
 
-# Install the Windows-side WSL watchdog: a 5-minute scheduled task that runs
-# `wsl -d Ubuntu -e true`. When WSL is up this is a no-op; when WSL has
-# crashed it boots the distro, and tinyproxy + claude-mobile.service then
-# come up on their own. Closes the at-logon-only gap of WslEuroleagueProxy.
+# Install the Windows-side WSL watchdog: scheduled task that runs `wsl -e true`
+# every 5 minutes. When WSL is up this is a no-op; when WSL has crashed it
+# boots the distro, and tinyproxy + claude-mobile.service then come up on
+# their own. Closes the at-logon-only gap of WslEuroleagueProxy.
+#
+# Two-phase install: schtasks /create handles the trigger/cmd (the bits its
+# CLI can express), then PowerShell Set-ScheduledTask flips the battery and
+# timeout settings that the CLI can't. Doing it as one XML import would
+# require admin elevation; this path runs as the current user.
 if command -v wslpath >/dev/null 2>&1 && [ -x /mnt/c/Windows/System32/cmd.exe ]; then
     WIN_USERPROFILE=$(/mnt/c/Windows/System32/cmd.exe /c 'echo %USERPROFILE%' 2>/dev/null | tr -d '\r\n')
+    if [ -z "$WIN_USERPROFILE" ] || [[ "$WIN_USERPROFILE" == *system32* ]]; then
+        echo "ERROR: %USERPROFILE% resolved to '$WIN_USERPROFILE' — refusing to install."
+        exit 1
+    fi
     WIN_PROFILE_WSL=$(wslpath "$WIN_USERPROFILE")
-    cp "$SCRIPT_DIR/wsl-watchdog.bat" "$WIN_PROFILE_WSL/wsl-watchdog.bat"
+
+    # CRLF endings on the .bat so cmd.exe parses multi-line constructs
+    # correctly even if future edits add `if errorlevel` blocks.
+    sed 's/$/\r/' "$SCRIPT_DIR/wsl-watchdog.bat" > "$WIN_PROFILE_WSL/wsl-watchdog.bat"
+
+    BAT_PATH_WIN="${WIN_USERPROFILE}\\wsl-watchdog.bat"
     /mnt/c/Windows/System32/schtasks.exe /create \
         /tn "WslWatchdog" \
-        /tr "$WIN_USERPROFILE\\wsl-watchdog.bat" \
+        /tr "$BAT_PATH_WIN" \
         /sc MINUTE /mo 5 /it /f
+    /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -Command "
+        \$s = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -MultipleInstances IgnoreNew -ExecutionTimeLimit (New-TimeSpan -Minutes 2);
+        Set-ScheduledTask -TaskName 'WslWatchdog' -Settings \$s | Out-Null
+    "
 else
     echo "Skipping WslWatchdog install — not running inside WSL on a Windows host."
 fi

--- a/infra/euroleague-proxy/install.sh
+++ b/infra/euroleague-proxy/install.sh
@@ -35,12 +35,35 @@ echo '[Service]' > /etc/systemd/system/tinyproxy.service.d/config.conf
 echo 'ExecStart=' >> /etc/systemd/system/tinyproxy.service.d/config.conf
 echo 'ExecStart=/usr/bin/tinyproxy -d -c /etc/tinyproxy/maccabipedia.conf' >> /etc/systemd/system/tinyproxy.service.d/config.conf
 
+# Auto-restart tinyproxy if it crashes while WSL stays up. Without this the
+# only recovery path is a full WSL reboot, since tinyproxy ships with no
+# Restart= directive.
+echo '[Service]' > /etc/systemd/system/tinyproxy.service.d/restart.conf
+echo 'Restart=on-failure' >> /etc/systemd/system/tinyproxy.service.d/restart.conf
+echo 'RestartSec=5s' >> /etc/systemd/system/tinyproxy.service.d/restart.conf
+
 mkdir -p /etc/systemd/system/tailscaled.service.d
 echo '[Unit]' > /etc/systemd/system/tailscaled.service.d/notify.conf
 echo 'OnFailure=notify-failure@%n.service' >> /etc/systemd/system/tailscaled.service.d/notify.conf
 
 systemctl daemon-reload
 systemctl enable --now tinyproxy tailscaled
+
+# Install the Windows-side WSL watchdog: a 5-minute scheduled task that runs
+# `wsl -d Ubuntu -e true`. When WSL is up this is a no-op; when WSL has
+# crashed it boots the distro, and tinyproxy + claude-mobile.service then
+# come up on their own. Closes the at-logon-only gap of WslEuroleagueProxy.
+if command -v wslpath >/dev/null 2>&1 && [ -x /mnt/c/Windows/System32/cmd.exe ]; then
+    WIN_USERPROFILE=$(/mnt/c/Windows/System32/cmd.exe /c 'echo %USERPROFILE%' 2>/dev/null | tr -d '\r\n')
+    WIN_PROFILE_WSL=$(wslpath "$WIN_USERPROFILE")
+    cp "$SCRIPT_DIR/wsl-watchdog.bat" "$WIN_PROFILE_WSL/wsl-watchdog.bat"
+    /mnt/c/Windows/System32/schtasks.exe /create \
+        /tn "WslWatchdog" \
+        /tr "$WIN_USERPROFILE\\wsl-watchdog.bat" \
+        /sc MINUTE /mo 5 /it /f
+else
+    echo "Skipping WslWatchdog install — not running inside WSL on a Windows host."
+fi
 
 echo ""
 echo "=== Done ==="

--- a/infra/euroleague-proxy/wsl-watchdog.bat
+++ b/infra/euroleague-proxy/wsl-watchdog.bat
@@ -1,0 +1,8 @@
+@echo off
+REM Boots the Ubuntu WSL distro if it's down. No-op when already running.
+REM Installed by infra/euroleague-proxy/install.sh and run every 5 min
+REM by the WslWatchdog scheduled task.
+REM
+REM Once WSL is up, tinyproxy (enabled, with Restart=on-failure) and
+REM claude-mobile.service (enabled + linger=yes) come up automatically.
+wsl -d Ubuntu -e true

--- a/infra/euroleague-proxy/wsl-watchdog.bat
+++ b/infra/euroleague-proxy/wsl-watchdog.bat
@@ -1,8 +1,9 @@
 @echo off
-REM Boots the Ubuntu WSL distro if it's down. No-op when already running.
-REM Installed by infra/euroleague-proxy/install.sh and run every 5 min
+REM Boots the default WSL distro if it's down. No-op when already running.
+REM Installed by infra/euroleague-proxy/install.sh and run every 5 minutes
 REM by the WslWatchdog scheduled task.
 REM
 REM Once WSL is up, tinyproxy (enabled, with Restart=on-failure) and
 REM claude-mobile.service (enabled + linger=yes) come up automatically.
-wsl -d Ubuntu -e true
+wsl -e true
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary

Fixes the May 9 → May 15 silent outage where the Euroleague residential proxy was unreachable for 5.5 days and 16 basketball uploads failed in a row.

**Root cause.** The existing \`WslEuroleagueProxy\` scheduled task only fires \"at logon time\". When WSL crashed mid-session (May 9) and no one signed in for a week, the distro stayed dead and so did tinyproxy / claude-mobile.

**Two complementary fixes:**

1. **`WslWatchdog` Windows scheduled task** — runs every 5 minutes, calls a new \`wsl-watchdog.bat\` that does \`wsl -d Ubuntu -e true\`. No-op when WSL is up; boots the distro when it's down. Once WSL is up, tinyproxy (enabled) and claude-mobile.service (enabled + linger=yes) cascade on their own.

2. **\`Restart=on-failure\` for tinyproxy** — drop-in at \`/etc/systemd/system/tinyproxy.service.d/restart.conf\`. Independently handles the case where the proxy itself dies while WSL stays up, without needing the watchdog. The upstream unit ships with no \`Restart=\` directive.

The watchdog and the restart policy are both installed by \`infra/euroleague-proxy/install.sh\` so a fresh proxy host gets both automatically.

**Remaining gap (out of scope):** if the PC is powered off, nothing in software can help.

## Test plan
- [x] Drop-in applied on live host (\`systemctl show tinyproxy --property=Restart\` → \`Restart=on-failure\`)
- [x] WslWatchdog created and manually triggered (\`Last Result: 0\`)
- [ ] Verify next scheduled run fires automatically (5 min cadence)
- [ ] After merge: re-run \`infra/euroleague-proxy/install.sh\` to confirm idempotent installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)