### PR TITLE
docs(dev): add skin deployment workflow guide

### DIFF
--- a/.claude/skin_deployment.md
+++ b/.claude/skin_deployment.md
@@ -1,0 +1,28 @@
+# MaccabiPedia Skin Deployment
+
+No automated push. One command prepares a ready-to-upload snapshot; the upload
+itself is manual via FileZilla.
+
+```bash
+# Build the upload snapshot for both skins (read-only; FTP creds auto-load
+# from infra/local-wiki/.env). Run with no args — the defaults cover the
+# common case (both skins, ~/maccabipedia_skins base).
+bash infra/local-wiki/scripts/deploy-skin.sh
+
+# → snapshot at ~/maccabipedia_skins/<ts>/{Maccabipedia,Metrolook}/
+# FileZilla: upload <snapshot>/<skin>/ → /public_html/skins/<skin>/
+# using the atomic-rename pattern the script prints.
+```
+
+## Notes (not surfaced by the scripts)
+
+- FTP creds live in `infra/local-wiki/.env`, **not the shell env** — an empty
+  `$MACCABIPEDIA_FTP_*` does not mean creds are missing.
+- Banner assets come from prod's `skins/Metrolook/assets` and are **shared by
+  both skins**; the Maccabipedia skin ships none of its own. (The sync op name
+  `maccabipedia-skin-assets` is misleading — it pulls Metrolook's dir.)
+- Scripts aren't executable → run with `bash`, not `./`.
+- `wfLoadSkin('Maccabipedia')` is already in prod LocalSettings — skip on
+  re-uploads.
+- Prod smoke test:
+  `MACCABIPEDIA_LOCAL_URL=https://www.maccabipedia.co.il uv run pytest -m integration infra/local-wiki/tests/test_maccabipedia_scaffold.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,4 @@ Every tool call result stays in context forever. Keep all outputs small:
 - `.claude/maccabipedia_research_sources.md` — External data sources: rosters, match results, historical records, photos, video
 - `.claude/maccabistats_knowledge.md` — maccabistats Python package API reference
 - `.claude/maccabipedia_youtube_channel.md` — MaccabiPedia YouTube channel conventions + Google Drive backup layout (used by `restore_deleted_football_video`)
+- `.claude/skin_deployment.md` — How skins reach production: read-only prod pull → local snapshot → manual FileZilla upload; creds live in `infra/local-wiki/.env`, not the shell env

--- a/infra/local-wiki/scripts/deploy-skin.sh
+++ b/infra/local-wiki/scripts/deploy-skin.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# deploy-skin.sh — one-command prep for a skin deploy: pull prod's banner
+# assets (read-only), then assemble the ready-to-upload snapshot.
+#
+# The upload itself is MANUAL (FileZilla) — this script stops at a snapshot
+# under ~/maccabipedia_skins/<ts>/ and prints the upload steps (those come
+# from prepare-skin-for-upload.sh, which it calls).
+#
+# Usage:
+#   bash deploy-skin.sh                       # both skins, default output base
+#   bash deploy-skin.sh --skin=maccabipedia
+#
+# Optional args pass through to prepare-skin-for-upload.sh (skin selection,
+# snapshot base path — see its header). FTP creds are read from
+# infra/local-wiki/.env by sync-from-prod.sh, not the shell environment.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> [1/2] pulling prod banner assets (read-only)"
+bash "${SCRIPT_DIR}/sync-from-prod.sh" maccabipedia-skin-assets
+
+echo
+echo "==> [2/2] assembling upload snapshot"
+bash "${SCRIPT_DIR}/prepare-skin-for-upload.sh" "$@"

--- a/infra/local-wiki/scripts/prepare-skin-for-upload.sh
+++ b/infra/local-wiki/scripts/prepare-skin-for-upload.sh
@@ -10,7 +10,7 @@
 #     <base>/<UTC timestamp with ms>/{Metrolook,Maccabipedia}/...
 #
 # Default base: ~/maccabipedia_skins/
-# Override:     ./prepare-skin-for-upload.sh /mnt/c/Users/roee/Desktop/maccabipedia_skins
+# Override:     ./prepare-skin-for-upload.sh /path/to/output-base
 #               (use a /mnt/c/... base on WSL if you want the snapshots
 #               on the Windows desktop where FileZilla can see them)
 #


### PR DESCRIPTION
## What

- **`infra/local-wiki/scripts/deploy-skin.sh`** — one command that chains the two existing steps: `sync-from-prod.sh maccabipedia-skin-assets` (read-only banner-asset pull) → `prepare-skin-for-upload.sh` (snapshot assembly). Pass-through args go to the latter (`--skin=…`, base path). The upload to prod stays **manual** (FileZilla).
- **`.claude/skin_deployment.md`** — a short runbook (≈29 lines) + a CLAUDE.md §7 reference entry.

## Why

The skin deploy workflow had to be reconstructed during a recent re-upload. Rather than a wall of prose, this captures it as a runnable script plus the few facts the scripts *don't* surface:

- **FTP creds live in `infra/local-wiki/.env`**, not the shell env — `echo $MACCABIPEDIA_FTP_*` looking empty does not mean creds are missing.
- **Banner assets are Metrolook's, shared by both skins** — the Maccabipedia skin ships none of its own, and the sync op name `maccabipedia-skin-assets` is misleading.
- **`synced/` is gitignored** → the pull must run before assembly (the wrapper does both).
- Scripts aren't `chmod +x` → invoke with `bash`.
- The prod smoke test has **3 expected harness-artifact failures**; clean signal is `test_maccabipedia_scaffold.py`.

## Verification

`deploy-skin.sh` was run end-to-end from a clean (empty `synced/`) worktree — it pulled assets and produced the snapshot. Diff is one small script + docs; no application code touched, so `pytest`/`mypy` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
