### PR TITLE
fix(dev): drop unused logo preload from Maccabipedia skin

### DIFF
--- a/skins/Maccabipedia/includes/SkinMaccabipedia.php
+++ b/skins/Maccabipedia/includes/SkinMaccabipedia.php
@@ -61,6 +61,10 @@ class SkinMaccabipedia extends SkinMustache {
 			. '/skins/Maccabipedia/assets/';
 		return [
 			'logo-url'         => Title::newMainPage()->getLocalURL(),
+			// The skin renders its own logo here, not core's mw-logo element, so
+			// the SkinModule `logo` feature stays OFF in skin.json — enabling it
+			// preloads an unused logo (the change-your-logo.svg placeholder absent
+			// $wgLogos) and the browser warns "preloaded but not used".
 			'logo-image-src'   => $skinAssetsBase . 'images/logo.png',
 			'primary-dropdowns' => $this->buildPrimaryDropdowns(),
 			'standalone-link'  => [

--- a/skins/Maccabipedia/skin.json
+++ b/skins/Maccabipedia/skin.json
@@ -46,8 +46,7 @@
 				"i18n-all-lists-margins": true,
 				"i18n-headings": true,
 				"elements": true,
-				"interface": true,
-				"logo": true
+				"interface": true
 			}
 		},
 		"skins.maccabipedia.styles": {


### PR DESCRIPTION
## What

Removes the unused `logo` feature from the Maccabipedia skin's `SkinModule`.

## Why

Opening the main page in dev tools surfaced this console warning:

> The resource `…/resources/assets/change-your-logo.svg` was preloaded using link preload but not used within a few seconds from the window's load event.

**Root cause:** `skin.json` enabled `"logo": true` on `skins.maccabipedia.interface`. Core MediaWiki emits a `<link rel="preload" as="image">` for the wiki logo whenever that feature is on. But the skin renders its **own** logo — `templates/skin.mustache` points an `<img>` at `images/logo.png` and uses none of core's `mw-logo` markup. With no `$wgLogos` configured, core preloaded the default placeholder `change-your-logo.svg`, which nothing on the page consumes → the warning.

The visible logo was never affected; this only drops a dead preload hint (and the unused `mw-logo` CSS the feature pulls in).

## Changes

- `skins/Maccabipedia/skin.json` — remove `"logo": true` from the SkinModule features.
- `skins/Maccabipedia/includes/SkinMaccabipedia.php` — comment at the custom-logo wiring noting why the `logo` feature must stay off (the discoverable spot for anyone touching the logo). No regression test: the failure is a benign console warning visible on any page load, not the kind of locally-invisible, prod-biting bug the existing skin guards exist for.

## Note

Won't reach prod until a skin deploy — the skin ships via the manual FTP workflow (`sync-from-prod → prepare-skin-for-upload → upload`), not auto-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
