### PR TITLE
fix(dev): set $wgLogos so schema.org publisher logo isn't the placeholder

### DIFF
--- a/infra/local-wiki/config/LocalSettings.shared.php
+++ b/infra/local-wiki/config/LocalSettings.shared.php
@@ -262,6 +262,18 @@ wfLoadExtension('WikiSEO'); // https://www.mediawiki.org/wiki/Extension:WikiSEO,
 $wgWikiSeoDefaultImage = 'File:Maccabipedia logo.png';
 $wgTwitterSiteHandle = '@maccabipedia';
 
+# Core logo. No skin actually uses it (Metrolook + Maccabipedia each render
+# their own app-header logo), but WikiSEO reads it for the schema.org
+# publisher logo in its JSON-LD — left unset it falls back to MediaWiki's
+# change-your-logo.svg placeholder. Point it at the same image as
+# $wgWikiSeoDefaultImage above: the uploaded File "Maccabipedia logo.png"
+# (e/e6 = MD5 of that filename; stable unless the File is renamed). We build
+# from $wgScriptPath, not $wgUploadPath — the latter is still false at
+# LocalSettings time (core resolves it later in Setup.php). NOTE: this image
+# lives on prod's wiki, so the URL 404s on the local replica; that's
+# harmless — it only affects SEO metadata, which dev never renders.
+$wgLogos = [ '1x' => "$wgScriptPath/images/e/e6/Maccabipedia_logo.png" ];
+
 // Welcome any new user with our default msg
 wfLoadExtension('NewUserMessage');  //https://www.mediawiki.org/wiki/Extension:NewUserMessage
 


### PR DESCRIPTION
## What

Sets `$wgLogos` so MediaWiki's core logo is the real Maccabipedia logo instead of the default placeholder.

## Why

Follow-up to #128. While verifying that fix on prod, the page's schema.org JSON-LD still referenced `resources/assets/change-your-logo.svg` — this time as the **publisher logo**. That block is emitted by the **WikiSEO** extension, which reads MediaWiki's core logo config for `publisher.logo`. `$wgLogos` was unset, so it fell back to core's `change-your-logo.svg` placeholder on every page.

No skin uses the core logo (Metrolook and the Maccabipedia skin each render their own app-header logo), so nothing visible was ever affected — this is purely an SEO/structured-data correctness fix.

## Change

`infra/local-wiki/config/LocalSettings.shared.php`:

```php
$wgLogos = [ '1x' => "$wgScriptPath/images/e/e6/Maccabipedia_logo.png" ];
```

Points at the same image `$wgWikiSeoDefaultImage` already uses — the uploaded File `Maccabipedia logo.png` (1459×699 PNG; `e/e6` is the MD5 of the filename, stable unless the File is renamed).

## Notes / decisions

- **`$wgScriptPath`, not `$wgUploadPath`** — the latter is still `false` at `LocalSettings.php` time (core resolves it later in `Setup.php`), so building from it would yield a broken path. `$wgScriptPath` is set in the env files, which load before `shared.php`.
- **Placed in `shared.php`, not `env.prod.php`** — the image only exists on prod's wiki, so the URL 404s on the local replica. That's harmless (it only feeds SEO metadata the dev env never renders, and local already showed a placeholder there). Kept in `shared.php` deliberately so the config stays version-controlled and reviewed; `env.prod.php` is server-only and unversioned. Documented inline.
- **Takes effect after a config deploy** + prod cache purge (separate from the skin FTP upload).

## Testing

- Non-integration local-wiki tests pass.
- `php -l` not run (PHP not installed locally); the change is a single array assignment matching surrounding style — CI/server will catch syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
