### PR TITLE
fix(dev): guard skin page-container deref against empty selection (Special:RecentChanges crash)

### DIFF
--- a/skins/Maccabipedia/scripts/mp-scripts-controller.js
+++ b/skins/Maccabipedia/scripts/mp-scripts-controller.js
@@ -4,7 +4,7 @@ function initMaccabipediaSpecificPageScripts($, $pageContainer) {
         'common-shirts-list-page-container': [initShirtsListPageScripts]
     }
 
-    if ($pageContainer) {
+    if ($pageContainer.length) {
         const pageContainerClasses = Array.from($pageContainer.get(0).classList)
 
         for (let pageContainerClass of pageContainerClasses) {

--- a/skins/Metrolook/js/mp-scripts-controller.js
+++ b/skins/Metrolook/js/mp-scripts-controller.js
@@ -4,7 +4,7 @@ function initMaccabipediaSpecificPageScripts($, $pageContainer) {
         'common-shirts-list-page-container': [initShirtsListPageScripts]
     }
 
-    if ($pageContainer) {
+    if ($pageContainer.length) {
         const pageContainerClasses = Array.from($pageContainer.get(0).classList)
 
         for (let pageContainerClass of pageContainerClasses) {


### PR DESCRIPTION
## What

Fixes a JS crash that aborts **all** skin scripts on special pages such as `Special:RecentChanges`.

## Why

On DOM-ready the controller computes:

```js
const $pageContainer = $('.mw-parser-output > *')
```

On a normal article this selection has element children, so per-page script dispatch works — and that's all an author opens on a dev setup. But on special pages the parser output has **no** element children, so the selection is empty. The dispatch guard used bare truthiness:

```js
if ($pageContainer) {                                    // jQuery object → always truthy
    const ... = Array.from($pageContainer.get(0).classList)  // .get(0) is undefined → throws
```

A jQuery object is always truthy regardless of match count, so `.get(0)` returned `undefined` and `.classList` threw `Cannot read properties of undefined (reading 'classList')`, aborting every subsequent skin script (app-header listener, sliders, ToC).

## Fix

`if ($pageContainer)` → `if ($pageContainer.length)` (test the match count — the correct jQuery idiom).

`mp-scripts-controller.js` is byte-identical in `skins/Maccabipedia/` and `skins/Metrolook/`. Metrolook is the **default** production skin, so this crash currently fires for all users on `Special:RecentChanges`, not just the opt-in `?useskin=maccabipedia` testers — both copies are fixed.

## Verification

- Reproduced by running the real function against an empty selection (threw the exact reported error); re-ran after the fix (no throw, content pages still dispatch correctly).
- `uv run pytest infra/local-wiki/tests/` — all pass.

## Deploy note

Skins reach prod via the manual FileZilla deploy (`.claude/skin_deployment.md`); merging this PR does not update production until the file is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
