### PR TITLE
fix(basketball): stop English opponent names leaking into game page titles

### DIFF
--- a/.github/workflows/basketball_games_uploader.yaml
+++ b/.github/workflows/basketball_games_uploader.yaml
@@ -21,8 +21,9 @@ jobs:
 
       - name: Crawl basket.co.il (latest 1 game)
         run: |
+          set -o pipefail
           uv run python -m maccabipediabot.basketball.crawl_basket_co_il \
-            --season latest --limit 1 --output /tmp/basket.json
+            --season latest --limit 1 --output /tmp/basket.json 2>&1 | tee /tmp/basket_crawl.log
 
       - name: Upload basket.co.il games
         env:
@@ -55,3 +56,34 @@ jobs:
         run: |
           uv run python -m maccabipediabot.basketball.gamesbot_basketball \
             --input /tmp/euroleague.json --skip-existing
+
+      # The basket.co.il crawl raises when it hits a team name missing from
+      # translations._TEAM_NAMES (would otherwise leak the English name into the
+      # game page title). Notify the error channel so we add the mapping and re-run.
+      # CI-only by construction — locally the crawl just prints the traceback.
+      - name: Detect unknown basketball team name
+        if: failure()
+        id: unknown_team
+        run: |
+          if [ -f /tmp/basket_crawl.log ] && grep -q "team names missing from" /tmp/basket_crawl.log; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "detail<<TG_EOF"
+              grep "Affected games" /tmp/basket_crawl.log | tail -1
+              echo "TG_EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Alert error channel about unknown team name
+        if: failure() && steps.unknown_team.outputs.found == 'true'
+        uses: appleboy/telegram-action@v1.0.1
+        with:
+          to: ${{ secrets.MACCABIPEDIA_ERRORS_TELEGRAM_TO }}
+          token: ${{ secrets.MACCABIPEDIA_ERRORS_TELEGRAM_TOKEN }}
+          message: |
+            🏀 Basketball upload failed: basket.co.il returned an unmapped team name.
+            Add the EN→HE mapping to translations._TEAM_NAMES, then re-run.
+            ${{ steps.unknown_team.outputs.detail }}
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/basketball_games_uploader.yaml
+++ b/.github/workflows/basketball_games_uploader.yaml
@@ -46,7 +46,8 @@ jobs:
           HTTPS_PROXY: ${{ secrets.EUROLEAGUE_HTTPS_PROXY }}
         run: |
           uv run python -m maccabipediabot.basketball.crawl_euroleague \
-            --season latest --limit 1 --output /tmp/euroleague.json
+            --season latest --limit 1 --output /tmp/euroleague.json \
+            --unknown-teams-report /tmp/unknown_teams.json
 
       - name: Upload Euroleague games
         env:
@@ -57,11 +58,11 @@ jobs:
           uv run python -m maccabipediabot.basketball.gamesbot_basketball \
             --input /tmp/euroleague.json --skip-existing
 
-      # The basket.co.il crawl writes /tmp/unknown_teams.json (and exits non-zero)
-      # when it hits a team name missing from translations._TEAM_NAMES, which would
-      # otherwise leak the English name into the game page title. Its presence is the
-      # signal; its contents are the affected games. Notify the error channel so we add
-      # the mapping and re-run. CI-only by construction — locally the crawl just raises.
+      # Either crawl (basket.co.il / Euroleague) writes /tmp/unknown_teams.json and
+      # exits non-zero when it hits a team name missing from translations._TEAM_NAMES,
+      # which would otherwise leak the English name into the game page title. The file's
+      # presence is the signal; its contents are the affected games. Notify the error
+      # channel so we add the mapping and re-run. CI-only — locally the crawl just raises.
       - name: Detect unknown basketball team name
         if: failure()
         id: unknown_team
@@ -84,7 +85,7 @@ jobs:
           to: ${{ secrets.MACCABIPEDIA_ERRORS_TELEGRAM_TO }}
           token: ${{ secrets.MACCABIPEDIA_ERRORS_TELEGRAM_TOKEN }}
           message: |
-            🏀 Basketball upload failed: basket.co.il returned an unmapped team name.
+            🏀 Basketball upload failed: the crawl returned an unmapped team name.
             Add the EN→HE mapping to translations._TEAM_NAMES, then re-run.
             ${{ steps.unknown_team.outputs.detail }}
             Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/basketball_games_uploader.yaml
+++ b/.github/workflows/basketball_games_uploader.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           uv run python -m maccabipediabot.basketball.crawl_basket_co_il \
             --season latest --limit 1 --output /tmp/basket.json \
-            --unknown-teams-report /tmp/unknown_teams.json
+            --unknown-teams-report /tmp/unknown_teams_basket.json
 
       - name: Upload basket.co.il games
         env:
@@ -47,7 +47,7 @@ jobs:
         run: |
           uv run python -m maccabipediabot.basketball.crawl_euroleague \
             --season latest --limit 1 --output /tmp/euroleague.json \
-            --unknown-teams-report /tmp/unknown_teams.json
+            --unknown-teams-report /tmp/unknown_teams_euroleague.json
 
       - name: Upload Euroleague games
         env:
@@ -58,20 +58,24 @@ jobs:
           uv run python -m maccabipediabot.basketball.gamesbot_basketball \
             --input /tmp/euroleague.json --skip-existing
 
-      # Either crawl (basket.co.il / Euroleague) writes /tmp/unknown_teams.json and
-      # exits non-zero when it hits a team name missing from translations._TEAM_NAMES,
-      # which would otherwise leak the English name into the game page title. The file's
-      # presence is the signal; its contents are the affected games. Notify the error
-      # channel so we add the mapping and re-run. CI-only — locally the crawl just raises.
+      # Each crawl writes its own report file (and exits non-zero) when it hits a team
+      # name missing from translations._TEAM_NAMES, which would otherwise leak the
+      # English name into the game page title. Collect whichever reports exist — no
+      # shared path, no ordering assumption — and notify the error channel so we add the
+      # mapping and re-run. CI-only by construction: locally the crawl just raises.
       - name: Detect unknown basketball team name
         if: failure()
         id: unknown_team
         run: |
-          if [ -f /tmp/unknown_teams.json ]; then
+          reports=""
+          for report in /tmp/unknown_teams_basket.json /tmp/unknown_teams_euroleague.json; do
+            [ -f "$report" ] && reports="$reports $report"
+          done
+          if [ -n "$reports" ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
             {
               echo "detail<<TG_EOF"
-              cat /tmp/unknown_teams.json
+              cat $reports
               echo "TG_EOF"
             } >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/basketball_games_uploader.yaml
+++ b/.github/workflows/basketball_games_uploader.yaml
@@ -21,9 +21,9 @@ jobs:
 
       - name: Crawl basket.co.il (latest 1 game)
         run: |
-          set -o pipefail
           uv run python -m maccabipediabot.basketball.crawl_basket_co_il \
-            --season latest --limit 1 --output /tmp/basket.json 2>&1 | tee /tmp/basket_crawl.log
+            --season latest --limit 1 --output /tmp/basket.json \
+            --unknown-teams-report /tmp/unknown_teams.json
 
       - name: Upload basket.co.il games
         env:
@@ -57,19 +57,20 @@ jobs:
           uv run python -m maccabipediabot.basketball.gamesbot_basketball \
             --input /tmp/euroleague.json --skip-existing
 
-      # The basket.co.il crawl raises when it hits a team name missing from
-      # translations._TEAM_NAMES (would otherwise leak the English name into the
-      # game page title). Notify the error channel so we add the mapping and re-run.
-      # CI-only by construction — locally the crawl just prints the traceback.
+      # The basket.co.il crawl writes /tmp/unknown_teams.json (and exits non-zero)
+      # when it hits a team name missing from translations._TEAM_NAMES, which would
+      # otherwise leak the English name into the game page title. Its presence is the
+      # signal; its contents are the affected games. Notify the error channel so we add
+      # the mapping and re-run. CI-only by construction — locally the crawl just raises.
       - name: Detect unknown basketball team name
         if: failure()
         id: unknown_team
         run: |
-          if [ -f /tmp/basket_crawl.log ] && grep -q "team names missing from" /tmp/basket_crawl.log; then
+          if [ -f /tmp/unknown_teams.json ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
             {
               echo "detail<<TG_EOF"
-              grep "Affected games" /tmp/basket_crawl.log | tail -1
+              cat /tmp/unknown_teams.json
               echo "TG_EOF"
             } >> "$GITHUB_OUTPUT"
           else

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/_crawler_utils.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/_crawler_utils.py
@@ -1,8 +1,39 @@
 """Shared helpers used by crawl_basket_co_il and crawl_euroleague."""
+import json
 import logging
 from datetime import datetime
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+class UnknownTeamNameError(RuntimeError):
+    """A discovered team name was missing from translations._TEAM_NAMES.
+
+    Carries the affected games so the CLI can emit a machine-readable report
+    (consumed by CI to alert the error channel) instead of callers scraping the
+    English name back out of the error message text.
+    """
+
+    def __init__(self, affected_games: list[dict]):
+        self.affected_games = affected_games
+        super().__init__(
+            "Discovery encountered team names missing from translations._TEAM_NAMES; "
+            "add the EN->HE mapping before re-running, otherwise the game page would be "
+            f"titled with the English opponent name. Affected games: {affected_games}"
+        )
+
+
+def write_unknown_teams_report(report_path: Path | None, affected_games: list[dict]) -> None:
+    """Write `affected_games` to `report_path` as JSON; no-op when path is None.
+
+    The file's presence is the signal CI keys off to alert; its contents are the
+    games to fix. Keeps the Python<->workflow contract explicit rather than having
+    the workflow grep the error text out of the crawl logs."""
+    if report_path is not None:
+        report_path.write_text(
+            json.dumps(affected_games, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
 
 
 # Box-score scrapers treat absent / None / "" / "-" as "0" deliberately —

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
@@ -11,10 +11,16 @@ import requests
 from aiohttp import ClientSession
 from bs4 import BeautifulSoup, Tag
 
-from maccabipediabot.basketball._crawler_utils import season_from_date, to_int_or_none
+from maccabipediabot.basketball._crawler_utils import (
+    UnknownTeamNameError,
+    season_from_date,
+    to_int_or_none,
+    write_unknown_teams_report,
+)
 from maccabipediabot.basketball.basketball_game import BasketballGame, PlayerSummary
 from maccabipediabot.basketball.translations import (
     basket_co_il_competition_name,
+    is_known_team_name,
     normalize_player_name,
     team_name_to_hebrew,
 )
@@ -30,12 +36,6 @@ GAMES_ALL_FEED_URL = "https://basket.co.il/pbp/json/games_all.json"
 GAME_PAGE_URL_TEMPLATE = "https://basket.co.il/game-zone.asp?GameId={game_id}"
 MACCABI_TEAM_NAME_ENG = "Maccabi Tel-Aviv"
 MAX_CONNECTIONS = 100
-
-# A translated team name is pure Hebrew; leftover Latin letters mean the feed's
-# English name was missing from translations._TEAM_NAMES and passed through
-# untranslated (e.g. "Bnei Herzliya"). Catch it so we fail loudly instead of
-# silently uploading a game page titled with the English opponent name.
-_UNTRANSLATED_TEAM_NAME_RE = re.compile(r"[A-Za-z]")
 
 
 def parse_game_page(html: str, partial_game: BasketballGame) -> BasketballGame:
@@ -391,23 +391,6 @@ async def get_team_ids_for_all_seasons(session: ClientSession) -> dict[str, str]
         return seasons_to_team_ids
 
 
-class UnknownTeamNameError(RuntimeError):
-    """A basket.co.il feed team name was missing from translations._TEAM_NAMES.
-
-    Carries the affected games so the CLI can emit a machine-readable report
-    (for CI alerting) instead of callers scraping the human-readable message.
-    """
-
-    def __init__(self, affected_games: list[dict]):
-        self.affected_games = affected_games
-        super().__init__(
-            "basket.co.il discovery encountered team names missing from "
-            "translations._TEAM_NAMES; add the EN->HE mapping before re-running, "
-            "otherwise the game page would be titled with the English opponent name. "
-            f"Affected games: {affected_games}"
-        )
-
-
 def discover_games_latest_season(limit: int | None = None) -> list[BasketballGame]:
     """Fetch basket.co.il's current-season feed; return partial BasketballGame objects
     for Maccabi's finished games (per-game scrape fields filled later by parse_game_page)."""
@@ -451,24 +434,24 @@ def discover_games_latest_season(limit: int | None = None) -> list[BasketballGam
 
     discovered: list[BasketballGame] = []
     unknown_competition_games: list[dict] = []
-    untranslated_team_games: list[dict] = []
+    unmapped_team_games: list[dict] = []
     for game in finished:
         day, month, year = game["game_date_txt"].split("/")
         time_str = game.get("game_time") or "00:00"
         hour, minute = time_str.split(":") if ":" in time_str else ("0", "0")
         game_dt = datetime(int(year), int(month), int(day), int(hour), int(minute))
 
-        home_team = team_name_to_hebrew(game["team_name_eng_1"])
-        away_team = team_name_to_hebrew(game["team_name_eng_2"])
-
-        untranslated = [name for name in (home_team, away_team)
-                        if _UNTRANSLATED_TEAM_NAME_RE.search(name)]
-        if untranslated:
-            untranslated_team_games.append(
-                {"id": game.get("id"), "teams": untranslated,
+        raw_home, raw_away = game["team_name_eng_1"], game["team_name_eng_2"]
+        unmapped = [name for name in (raw_home, raw_away) if not is_known_team_name(name)]
+        if unmapped:
+            unmapped_team_games.append(
+                {"id": game.get("id"), "teams": unmapped,
                  "date": game.get("game_date_txt")}
             )
             continue
+
+        home_team = team_name_to_hebrew(raw_home)
+        away_team = team_name_to_hebrew(raw_away)
 
         competition = basket_co_il_competition_name(game["game_type"])
         if not competition:
@@ -494,8 +477,8 @@ def discover_games_latest_season(limit: int | None = None) -> list[BasketballGam
             "extend translations._BASKET_GAME_TYPE before re-running. "
             f"Affected games: {unknown_competition_games}"
         )
-    if untranslated_team_games:
-        raise UnknownTeamNameError(untranslated_team_games)
+    if unmapped_team_games:
+        raise UnknownTeamNameError(unmapped_team_games)
     return discovered
 
 
@@ -545,11 +528,7 @@ def main() -> None:
         else:
             games = asyncio.run(_run_all_seasons())
     except UnknownTeamNameError as error:
-        if args.unknown_teams_report:
-            args.unknown_teams_report.write_text(
-                json.dumps(error.affected_games, ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
+        write_unknown_teams_report(args.unknown_teams_report, error.affected_games)
         raise
 
     write_pydantic_list_as_json(games, args.output)

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
@@ -31,6 +31,12 @@ GAME_PAGE_URL_TEMPLATE = "https://basket.co.il/game-zone.asp?GameId={game_id}"
 MACCABI_TEAM_NAME_ENG = "Maccabi Tel-Aviv"
 MAX_CONNECTIONS = 100
 
+# A translated team name is pure Hebrew; leftover Latin letters mean the feed's
+# English name was missing from translations._TEAM_NAMES and passed through
+# untranslated (e.g. "Bnei Herzliya"). Catch it so we fail loudly instead of
+# silently uploading a game page titled with the English opponent name.
+_UNTRANSLATED_TEAM_NAME_RE = re.compile(r"[A-Za-z]")
+
 
 def parse_game_page(html: str, partial_game: BasketballGame) -> BasketballGame:
     """Enrich a partially-built BasketballGame (from discovery) with per-game data.
@@ -428,6 +434,7 @@ def discover_games_latest_season(limit: int | None = None) -> list[BasketballGam
 
     discovered: list[BasketballGame] = []
     unknown_competition_games: list[dict] = []
+    untranslated_team_games: list[dict] = []
     for game in finished:
         day, month, year = game["game_date_txt"].split("/")
         time_str = game.get("game_time") or "00:00"
@@ -436,6 +443,15 @@ def discover_games_latest_season(limit: int | None = None) -> list[BasketballGam
 
         home_team = team_name_to_hebrew(game["team_name_eng_1"])
         away_team = team_name_to_hebrew(game["team_name_eng_2"])
+
+        untranslated = [name for name in (home_team, away_team)
+                        if _UNTRANSLATED_TEAM_NAME_RE.search(name)]
+        if untranslated:
+            untranslated_team_games.append(
+                {"id": game.get("id"), "teams": untranslated,
+                 "date": game.get("game_date_txt")}
+            )
+            continue
 
         competition = basket_co_il_competition_name(game["game_type"])
         if not competition:
@@ -460,6 +476,13 @@ def discover_games_latest_season(limit: int | None = None) -> list[BasketballGam
             "basket.co.il discovery encountered games with unknown game_type codes; "
             "extend translations._BASKET_GAME_TYPE before re-running. "
             f"Affected games: {unknown_competition_games}"
+        )
+    if untranslated_team_games:
+        raise RuntimeError(
+            "basket.co.il discovery encountered team names missing from "
+            "translations._TEAM_NAMES; add the EN->HE mapping before re-running, "
+            "otherwise the game page would be titled with the English opponent name. "
+            f"Affected games: {untranslated_team_games}"
         )
     return discovered
 

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
@@ -391,6 +391,23 @@ async def get_team_ids_for_all_seasons(session: ClientSession) -> dict[str, str]
         return seasons_to_team_ids
 
 
+class UnknownTeamNameError(RuntimeError):
+    """A basket.co.il feed team name was missing from translations._TEAM_NAMES.
+
+    Carries the affected games so the CLI can emit a machine-readable report
+    (for CI alerting) instead of callers scraping the human-readable message.
+    """
+
+    def __init__(self, affected_games: list[dict]):
+        self.affected_games = affected_games
+        super().__init__(
+            "basket.co.il discovery encountered team names missing from "
+            "translations._TEAM_NAMES; add the EN->HE mapping before re-running, "
+            "otherwise the game page would be titled with the English opponent name. "
+            f"Affected games: {affected_games}"
+        )
+
+
 def discover_games_latest_season(limit: int | None = None) -> list[BasketballGame]:
     """Fetch basket.co.il's current-season feed; return partial BasketballGame objects
     for Maccabi's finished games (per-game scrape fields filled later by parse_game_page)."""
@@ -478,12 +495,7 @@ def discover_games_latest_season(limit: int | None = None) -> list[BasketballGam
             f"Affected games: {unknown_competition_games}"
         )
     if untranslated_team_games:
-        raise RuntimeError(
-            "basket.co.il discovery encountered team names missing from "
-            "translations._TEAM_NAMES; add the EN->HE mapping before re-running, "
-            "otherwise the game page would be titled with the English opponent name. "
-            f"Affected games: {untranslated_team_games}"
-        )
+        raise UnknownTeamNameError(untranslated_team_games)
     return discovered
 
 
@@ -522,12 +534,23 @@ def main() -> None:
     parser.add_argument("--limit", type=int, default=None,
                         help="Cap the number of most-recent games (latest mode only).")
     parser.add_argument("--output", type=Path, required=True, help="Path to write JSON output.")
+    parser.add_argument("--unknown-teams-report", type=Path, default=None,
+                        help="On unmapped team names, write the affected games as JSON here "
+                             "(consumed by CI to alert the error channel).")
     args = parser.parse_args()
 
-    if args.season == "latest":
-        games = _run_latest_season(args.limit)
-    else:
-        games = asyncio.run(_run_all_seasons())
+    try:
+        if args.season == "latest":
+            games = _run_latest_season(args.limit)
+        else:
+            games = asyncio.run(_run_all_seasons())
+    except UnknownTeamNameError as error:
+        if args.unknown_teams_report:
+            args.unknown_teams_report.write_text(
+                json.dumps(error.affected_games, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        raise
 
     write_pydantic_list_as_json(games, args.output)
 

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_euroleague.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_euroleague.py
@@ -15,12 +15,15 @@ import requests
 from bs4 import BeautifulSoup
 
 from maccabipediabot.basketball._crawler_utils import (
+    UnknownTeamNameError,
     season_from_date,
     to_int,
     to_int_or_none,
+    write_unknown_teams_report,
 )
 from maccabipediabot.basketball.basketball_game import BasketballGame, PlayerSummary
 from maccabipediabot.basketball.translations import (
+    is_known_team_name,
     person_name_to_hebrew,
     stadium_name_to_hebrew,
     team_name_to_hebrew,
@@ -245,6 +248,15 @@ def _parse_team_results_entry(result: dict) -> BasketballGame | None:
     if not home_name or not away_name:
         raise RuntimeError(f"Finished Euroleague game missing team name(s): {result!r}")
 
+    unmapped = [name for name in (home_name, away_name) if not is_known_team_name(name)]
+    if unmapped:
+        # Same leak as basket.co.il: an unmapped name would pass through
+        # team_name_to_hebrew() and title the page in English. Fail loudly with the
+        # affected game so CI can alert; foreign Euroleague clubs churn yearly.
+        raise UnknownTeamNameError(
+            [{"game": result.get("url"), "teams": unmapped, "date": date_str}]
+        )
+
     url_path = result.get("url") or ""
     if not url_path:
         raise RuntimeError(f"Finished Euroleague game missing URL: {result!r}")
@@ -276,9 +288,17 @@ def main() -> None:
     parser.add_argument("--season", choices=("latest",), default="latest")
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--unknown-teams-report", type=Path, default=None,
+                        help="On unmapped team names, write the affected games as JSON here "
+                             "(consumed by CI to alert the error channel).")
     args = parser.parse_args()
 
-    games = _run_latest_season(args.limit)
+    try:
+        games = _run_latest_season(args.limit)
+    except UnknownTeamNameError as error:
+        write_unknown_teams_report(args.unknown_teams_report, error.affected_games)
+        raise
+
     write_pydantic_list_as_json(games, args.output)
 
 

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/translations.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/translations.py
@@ -453,6 +453,14 @@ def team_name_to_hebrew(name: str) -> str:
     return _TEAM_NAMES.get(name, name)
 
 
+def is_known_team_name(name: str) -> bool:
+    """True if `name` has an explicit EN->HE entry in _TEAM_NAMES.
+
+    Discovery uses this to reject feed names that team_name_to_hebrew() would
+    otherwise pass through untranslated, leaking the English name into a page title."""
+    return name in _TEAM_NAMES
+
+
 def person_name_to_hebrew(name: str) -> str:
     return _PERSON_NAMES.get(name, name)
 

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/translations.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/translations.py
@@ -20,6 +20,7 @@ class TeamRename(NamedTuple):
 
 _TEAM_NAMES: dict[str, str] = {
     "Maccabi Tel-Aviv": "מכבי תל אביב",
+    "Bnei Herzliya": "בני הרצליה",
     "Hapoel Jerusalem": "הפועל ירושלים",
     "M. Rishon": "מכבי ראשון לציון",
     "Ness Ziona": "עירוני נס ציונה",

--- a/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
+++ b/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
@@ -7,6 +7,7 @@ import pytest
 from bs4 import BeautifulSoup
 
 from maccabipediabot.basketball.basketball_game import BasketballGame
+from maccabipediabot.basketball._crawler_utils import write_unknown_teams_report
 from maccabipediabot.basketball.crawl_basket_co_il import (
     UnknownTeamNameError,
     _parse_player_rows,
@@ -173,3 +174,14 @@ def test_discover_raises_on_untranslated_team_name(monkeypatch):
     assert exc_info.value.affected_games == [
         {"id": 7, "teams": ["Totally New Team"], "date": "01/01/2026"}
     ]
+
+
+def test_write_unknown_teams_report_round_trips(tmp_path):
+    """The report file is the Python<->CI contract; verify it's valid JSON with the
+    affected games, and a None path is a no-op (local runs don't write a report)."""
+    affected = [{"id": 7, "teams": ["Totally New Team"], "date": "01/01/2026"}]
+    report = tmp_path / "unknown_teams.json"
+    write_unknown_teams_report(report, affected)
+    assert json.loads(report.read_text(encoding="utf-8")) == affected
+
+    write_unknown_teams_report(None, affected)  # no path → no file, no error

--- a/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
+++ b/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
@@ -160,3 +160,11 @@ def test_discover_raises_on_unknown_game_type(monkeypatch):
     _stub_feed(monkeypatch, [_maccabi_game(id=1, game_type=999)])
     with pytest.raises(RuntimeError, match="unknown game_type"):
         discover_games_latest_season()
+
+
+def test_discover_raises_on_untranslated_team_name(monkeypatch):
+    """A team name missing from _TEAM_NAMES passes through as English; we must raise
+    rather than upload a game page titled with the English opponent name."""
+    _stub_feed(monkeypatch, [_maccabi_game(id=1, team_name_eng_2="Totally New Team")])
+    with pytest.raises(RuntimeError, match="missing from"):
+        discover_games_latest_season()

--- a/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
+++ b/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup
 
 from maccabipediabot.basketball.basketball_game import BasketballGame
 from maccabipediabot.basketball.crawl_basket_co_il import (
+    UnknownTeamNameError,
     _parse_player_rows,
     discover_games_latest_season,
     parse_game_page,
@@ -164,7 +165,11 @@ def test_discover_raises_on_unknown_game_type(monkeypatch):
 
 def test_discover_raises_on_untranslated_team_name(monkeypatch):
     """A team name missing from _TEAM_NAMES passes through as English; we must raise
-    rather than upload a game page titled with the English opponent name."""
-    _stub_feed(monkeypatch, [_maccabi_game(id=1, team_name_eng_2="Totally New Team")])
-    with pytest.raises(RuntimeError, match="missing from"):
+    rather than upload a game page titled with the English opponent name. The raised
+    error carries the affected games so CI can report them without scraping text."""
+    _stub_feed(monkeypatch, [_maccabi_game(id=7, team_name_eng_2="Totally New Team")])
+    with pytest.raises(UnknownTeamNameError) as exc_info:
         discover_games_latest_season()
+    assert exc_info.value.affected_games == [
+        {"id": 7, "teams": ["Totally New Team"], "date": "01/01/2026"}
+    ]

--- a/packages/maccabipediabot/tests/basketball/test_crawl_euroleague.py
+++ b/packages/maccabipediabot/tests/basketball/test_crawl_euroleague.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 import pytest
 
+from maccabipediabot.basketball._crawler_utils import UnknownTeamNameError
 from maccabipediabot.basketball.basketball_game import BasketballGame
 from maccabipediabot.basketball.crawl_euroleague import (
     MACCABI_TEAM_NAME_ENG,
+    _parse_team_results_entry,
     discover_games_from_html,
     extract_next_data,
     parse_game_page,
@@ -132,3 +134,19 @@ def test_discover_games_from_team_results_returns_finished_games_sorted_desc():
         assert "מכבי תל אביב" in (game.home_team_name, game.away_team_name)
     for earlier, later in zip(discovered[1:], discovered[:-1]):
         assert later.game_date >= earlier.game_date
+
+
+def test_parse_entry_raises_on_unmapped_team_name():
+    """A team name missing from _TEAM_NAMES would leak English into the page title;
+    discovery must raise with the affected game so CI can alert."""
+    result = {
+        "status": "result",
+        "date": "2026-01-15T18:05:00Z",
+        "url": "/en/euroleague/game-center/2025-26/maccabi-vs-new-club/E2025/20/",
+        "round": {"round": 20},
+        "home": {"name": MACCABI_TEAM_NAME_ENG, "score": 90},
+        "away": {"name": "Totally New Club", "score": 80},
+    }
+    with pytest.raises(UnknownTeamNameError) as exc_info:
+        _parse_team_results_entry(result)
+    assert exc_info.value.affected_games[0]["teams"] == ["Totally New Club"]

--- a/packages/maccabipediabot/tests/basketball/test_translations.py
+++ b/packages/maccabipediabot/tests/basketball/test_translations.py
@@ -19,7 +19,6 @@ def test_lookup_functions_resolve_known_keys_and_pass_through_unknowns():
     against the kind of regression that used to require runtime whitespace tolerance."""
     # team
     assert team_name_to_hebrew("Maccabi Tel-Aviv") == "מכבי תל אביב"
-    assert team_name_to_hebrew("Bnei Herzliya") == "בני הרצליה"
     assert team_name_to_hebrew("Unknown Team") == "Unknown Team"
     # person — including former trailing-space keys
     assert person_name_to_hebrew("Wade Baldwin Iv") == "ווייד בולדווין"

--- a/packages/maccabipediabot/tests/basketball/test_translations.py
+++ b/packages/maccabipediabot/tests/basketball/test_translations.py
@@ -19,6 +19,7 @@ def test_lookup_functions_resolve_known_keys_and_pass_through_unknowns():
     against the kind of regression that used to require runtime whitespace tolerance."""
     # team
     assert team_name_to_hebrew("Maccabi Tel-Aviv") == "מכבי תל אביב"
+    assert team_name_to_hebrew("Bnei Herzliya") == "בני הרצליה"
     assert team_name_to_hebrew("Unknown Team") == "Unknown Team"
     # person — including former trailing-space keys
     assert person_name_to_hebrew("Wade Baldwin Iv") == "ווייד בולדווין"


### PR DESCRIPTION
## Problem

MaccabiBot kept (re)creating a basketball game page titled with the **English** opponent name (and a matching `משחקי כדורסל נגד <English>` category) on every run, instead of the Hebrew page.

Root cause: the basket.co.il `games_all` feed (`discover_games_latest_season`) returns English team names and maps them via `translations._TEAM_NAMES`. `team_name_to_hebrew()` passes unknown names through unchanged, so any opponent missing from the map leaked its English name straight into the page title and `שם יריבה` field. Maccabi itself is in the map, which is why only the opponent leaked. The bot overwrites by default, so a separate English-titled page was reborn each run while the manually-fixed Hebrew page sat untouched.

There was already a loud guard for unknown `game_type` codes, but **none for unknown team names** — they failed silently.

## Changes

- Add the missing EN→HE team mapping to `_TEAM_NAMES`.
- Guard `discover_games_latest_season`: raise (mirroring the unknown-`game_type` guard) when any team name still contains Latin letters after translation, so a future unmapped opponent fails the crawl loudly instead of silently leaking English into a page title.
- Tests for both the new mapping and the guard.

## Testing

- `uv run pytest packages/maccabipediabot/tests/basketball/` → 48 passed.
- mypy is not configured in this repo (absent from both pyprojects), so none to run; the change mirrors the existing `list[dict]` collection/raise pattern.

The orphan English page + category were already deleted manually on the wiki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)