### PR TITLE
feat: purge players portal after football/volleyball game uploads

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/football/gamesbot.py
+++ b/packages/maccabipediabot/src/maccabipediabot/football/gamesbot.py
@@ -361,9 +361,11 @@ def upload_games_to_maccabipedia(maccabi_games_to_add: MaccabiGamesStats):
 
     logging.info("Finished adding new games.")
 
-    # The main page shows the latest 5 games list, so purge it too
+    # The main page shows the latest 5 games list, and the players portal shows
+    # the top scorers/assisters leaderboards, so purge them too
     if all_pages_to_purge:
         all_pages_to_purge.add("עמוד ראשי")
+        all_pages_to_purge.add("פורטל שחקנים")
 
     # Batch purge all collected pages at the end
     if SHOULD_SAVE and SHOULD_PURGE_RELATED_PAGES:

--- a/packages/maccabipediabot/src/maccabipediabot/volleyball/gamesbot_volleyball.py
+++ b/packages/maccabipediabot/src/maccabipediabot/volleyball/gamesbot_volleyball.py
@@ -267,9 +267,11 @@ def create_or_update_volleyball_game_pages(games_to_add: List[VolleyballGame]):
 
     logging.info("Finished adding new games.")
 
-    # The main page shows the latest 5 games list, so purge it too
+    # The main page shows the latest 5 games list, and the players portal's
+    # volleyball tab shows the points/appearances record leaderboards, so purge them too
     if all_pages_to_purge:
         all_pages_to_purge.add("עמוד ראשי")
+        all_pages_to_purge.add("פורטל שחקנים")
 
     # Batch purge all collected pages at the end
     if SHOULD_SAVE and SHOULD_PURGE_RELATED_PAGES:


### PR DESCRIPTION
## What
Add the players portal page (`פורטל שחקנים`) to the post-upload purge set in both the football and volleyball game bots.

## Why
`פורטל שחקנים` is a unified, multi-sport portal page with per-sport tabs. Each tab transcludes a category page that renders Cargo-driven leaderboards:
- **Football** tab → top scorers / top assisters
- **Volleyball** tab → points record holders (`שיאני נקודות`) and appearances record holders (`שיאני הופעות`)

These leaderboards aggregate across all games, so they go stale on *every* game upload — regardless of which players appeared. The existing per-game purge only covers pages tied to that game's roster, so the portal was never refreshed.

## Change
In each bot's `upload`/`create_or_update` flow, the portal is added to the fixed-pages purge set right next to `עמוד ראשי` (same `if all_pages_to_purge:` guard, same `purge(forcelinkupdate=True)` batch). Purging the portal re-parses its transclusions and re-runs the embedded Cargo queries.

## Notes
- Basketball is intentionally out of scope — its game bot has no purge logic at all (known gap), so there's nothing to hook into without first adding the whole mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
