### PR TITLE
docs(dev): clarify how to run the skin deploy

### DIFF
--- a/.claude/skin_deployment.md
+++ b/.claude/skin_deployment.md
@@ -4,15 +4,32 @@ No automated push. One command prepares a ready-to-upload snapshot; the upload
 itself is manual via FileZilla.
 
 ```bash
-# Build the upload snapshot for both skins (read-only; FTP creds auto-load
-# from infra/local-wiki/.env). Run with no args — the defaults cover the
-# common case (both skins, ~/maccabipedia_skins base).
-bash infra/local-wiki/scripts/deploy-skin.sh
+# Build the upload snapshot (read-only; FTP creds auto-load from
+# infra/local-wiki/.env). No args = both skins; use --skin to limit it.
+bash infra/local-wiki/scripts/deploy-skin.sh                  # both skins
+bash infra/local-wiki/scripts/deploy-skin.sh --skin=maccabipedia   # just the new skin
 
 # → snapshot at ~/maccabipedia_skins/<ts>/{Maccabipedia,Metrolook}/
 # FileZilla: upload <snapshot>/<skin>/ → /public_html/skins/<skin>/
 # using the atomic-rename pattern the script prints.
 ```
+
+## Running it (who runs the script)
+
+The script does NOT write to prod — it makes a **read-only** FTP pull of prod's
+banner assets and assembles a **local** snapshot; only the FileZilla upload
+mutates prod. But because it connects to prod, Claude Code's auto-mode safety
+classifier flags it as a production action and **blocks Claude from running it
+directly**. Two ways through:
+
+- **You run it in-session** (simplest) — type the command with a leading `!` so
+  its output lands in the conversation:
+  `! bash infra/local-wiki/scripts/deploy-skin.sh --skin=maccabipedia`
+- **Grant a permission rule** — add a Bash allow rule for
+  `infra/local-wiki/scripts/deploy-skin.sh` (and `sync-from-prod.sh`, which it
+  calls) in `.claude/settings.json`, then Claude can build the snapshot itself.
+
+Either way the upload step stays manual (FileZilla).
 
 ## Notes (not surfaced by the scripts)
 


### PR DESCRIPTION
Documents the operational gap we hit deploying the Maccabipedia skin: `deploy-skin.sh` makes a read-only FTP pull from prod, so Claude Code's auto-mode safety classifier blocks Claude from running it directly.

Adds a **Running it** section to `.claude/skin_deployment.md`:
- run it in-session via `! bash infra/local-wiki/scripts/deploy-skin.sh --skin=maccabipedia`, or add a Bash permission rule
- clarifies the script never writes to prod — only the manual FileZilla upload does
- documents the `--skin=` flag (build just one skin)

Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)