### PR TITLE
fix(calendar): guard end-of-season empty results in update_last_game

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/calendar/main.py
+++ b/packages/maccabipediabot/src/maccabipediabot/calendar/main.py
@@ -120,12 +120,7 @@ def update_last_game(url: str, calendar_id: str) -> None:
     """
 
     _logger.info("--- Updating Last Game: ---")
-
-    last_games = fetch_games_from_maccabi_tlv_site(url, to_update_last_game=True)
-    if not last_games:
-        _logger.info("No last game found on the maccabi-tlv site; skipping last-game update.")
-        return
-    last_game = last_games[0]
+    last_game = fetch_games_from_maccabi_tlv_site(url, to_update_last_game=True)[0]
 
     # At the end of a season the last played game has no event at/after it in the
     # calendar, so this query comes back empty. Skip rather than index into [].

--- a/packages/maccabipediabot/src/maccabipediabot/calendar/main.py
+++ b/packages/maccabipediabot/src/maccabipediabot/calendar/main.py
@@ -120,8 +120,20 @@ def update_last_game(url: str, calendar_id: str) -> None:
     """
 
     _logger.info("--- Updating Last Game: ---")
-    last_game = fetch_games_from_maccabi_tlv_site(url, to_update_last_game=True)[0]
-    last_event = fetch_games_from_calendar(calendar_id, last_game['start']['dateTime'] + '+02:00', 1)[0]
+
+    last_games = fetch_games_from_maccabi_tlv_site(url, to_update_last_game=True)
+    if not last_games:
+        _logger.info("No last game found on the maccabi-tlv site; skipping last-game update.")
+        return
+    last_game = last_games[0]
+
+    # At the end of a season the last played game has no event at/after it in the
+    # calendar, so this query comes back empty. Skip rather than index into [].
+    last_events = fetch_games_from_calendar(calendar_id, last_game['start']['dateTime'] + '+02:00', 1)
+    if not last_events:
+        _logger.info("No matching calendar event at/after the last game; skipping last-game update.")
+        return
+    last_event = last_events[0]
 
     if 'extendedProperties' in last_game and 'extendedProperties' in last_event:
         if last_game['extendedProperties']['shared']['url'] == last_event['extendedProperties']['shared']['url']:

--- a/packages/maccabipediabot/tests/calendar/test_update_last_game.py
+++ b/packages/maccabipediabot/tests/calendar/test_update_last_game.py
@@ -21,14 +21,3 @@ def test_update_last_game_skips_when_no_calendar_event():
         main.update_last_game('http://example.com/season', 'calendar-id')
 
     update_existing_event.assert_not_called()
-
-
-def test_update_last_game_skips_when_no_game_on_site():
-    """The site has no last game to read; update_last_game must skip, not raise."""
-    with patch.object(main, 'fetch_games_from_maccabi_tlv_site', return_value=[]), \
-            patch.object(main, 'fetch_games_from_calendar') as fetch_games_from_calendar, \
-            patch.object(main, 'update_existing_event') as update_existing_event:
-        main.update_last_game('http://example.com/season', 'calendar-id')
-
-    fetch_games_from_calendar.assert_not_called()
-    update_existing_event.assert_not_called()

--- a/packages/maccabipediabot/tests/calendar/test_update_last_game.py
+++ b/packages/maccabipediabot/tests/calendar/test_update_last_game.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+from maccabipediabot.calendar import main
+
+_LAST_GAME = {
+    'summary': 'מכבי תל אביב נגד הפועל באר שבע',
+    'start': {'dateTime': '2026-05-25T20:00:00'},
+}
+
+
+def test_update_last_game_skips_when_no_calendar_event():
+    """End of season: the last played game has no event at/after it in the calendar.
+
+    fetch_games_from_calendar returns [] and update_last_game must skip gracefully
+    instead of raising IndexError (the bug that failed the scheduled football
+    calendar workflow every run once the season ended).
+    """
+    with patch.object(main, 'fetch_games_from_maccabi_tlv_site', return_value=[_LAST_GAME]), \
+            patch.object(main, 'fetch_games_from_calendar', return_value=[]), \
+            patch.object(main, 'update_existing_event') as update_existing_event:
+        main.update_last_game('http://example.com/season', 'calendar-id')
+
+    update_existing_event.assert_not_called()
+
+
+def test_update_last_game_skips_when_no_game_on_site():
+    """The site has no last game to read; update_last_game must skip, not raise."""
+    with patch.object(main, 'fetch_games_from_maccabi_tlv_site', return_value=[]), \
+            patch.object(main, 'fetch_games_from_calendar') as fetch_games_from_calendar, \
+            patch.object(main, 'update_existing_event') as update_existing_event:
+        main.update_last_game('http://example.com/season', 'calendar-id')
+
+    fetch_games_from_calendar.assert_not_called()
+    update_existing_event.assert_not_called()


### PR DESCRIPTION
## What

The scheduled **Update MaccabiPedia Calendar (Football)** workflow has been failing on every run (19 failures in the analysis window, recurring since ~May 26) with:

```
IndexError: list index out of range
  calendar/main.py:124, in update_last_game
```

## Why

`update_last_game` does blind `[0]` indexing on two fetches:

```python
last_game  = fetch_games_from_maccabi_tlv_site(url, to_update_last_game=True)[0]
last_event = fetch_games_from_calendar(calendar_id, last_game['start']['dateTime'] + '+02:00', 1)[0]
```

Once the season ends, the last *played* game has no calendar event at/after its start time, so `fetch_games_from_calendar(...)` returns `[]` and `[0]` raises. This lines up with the end of the IPL regular season.

## Fix

Guard both fetches with early returns and log a skip message, so the workflow completes cleanly when there's nothing to update. Line 123 had the same fragility and is guarded too.

## Tests

Adds `tests/calendar/test_update_last_game.py` covering both empty-result paths (empty calendar query, empty site fetch). Full suite: 529 passed, 1 skipped.

> Context: found while analyzing the repo's GitHub Actions failures. This PR fixes the one genuine code bug. The other top failure sources are config/infra, not code: the FTP-upload workflow is red on every run because its `MACCABIPEDIA_FTP*` secrets don't exist (left untouched per request), the basketball Euroleague proxy failures appear resolved by today's `EUROLEAGUE_HTTPS_PROXY` rotation, and the rest are transient `maccabipedia.co.il` timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)