### PR TITLE
test(dev): make local-wiki integration smoke tests prod-aware

### DIFF
--- a/infra/local-wiki/tests/test_maccabipedia_scaffold.py
+++ b/infra/local-wiki/tests/test_maccabipedia_scaffold.py
@@ -10,6 +10,7 @@ loadable logo + powered-by assets, and Title-encoded menu hrefs.
 from __future__ import annotations
 
 import re
+from urllib.parse import urljoin, urlparse
 
 import pytest
 import requests
@@ -217,14 +218,22 @@ def test_no_broken_dropdown_hrefs(maccabipedia_anon_html: str) -> None:
     assert not broken, f"found {len(broken)} menu link(s) degraded to href=\"#\""
 
 
-def test_no_prod_url_leakage(maccabipedia_anon_html: str) -> None:
+def test_no_prod_url_leakage(base_url: str, maccabipedia_anon_html: str) -> None:
     """No hrefs/text mentioning the production wiki should leak through the
-    local stack."""
+    local stack.
+
+    This is a *local-mirror* invariant (catch hardcoded prod URLs in dev). When
+    the suite is pointed at prod itself the page legitimately contains its own
+    domain, so the assertion is meaningless there — skip it."""
+    if "maccabipedia.co.il" in urlparse(base_url).netloc:
+        pytest.skip("target host is the prod wiki; prod-URL-leakage check is local-only")
     assert "maccabipedia.co.il" not in maccabipedia_anon_html
 
 
 @pytest.mark.parametrize("asset", ["logo", "powered-by"])
-def test_static_asset_loads(maccabipedia_anon_html: str, asset: str) -> None:
+def test_static_asset_loads(
+    base_url: str, maccabipedia_anon_html: str, asset: str
+) -> None:
     """The skin's own logo (assets/images/logo.png) and the powered-by-MediaWiki
     <img src> must be present and resolve to HTTP 200. Both are $wgServer-prefixed
     absolute URLs (see SkinMaccabipedia::buildAppHeaderData/buildAppFooterData).
@@ -238,7 +247,9 @@ def test_static_asset_loads(maccabipedia_anon_html: str, asset: str) -> None:
     }[asset]
     match = re.search(pattern, maccabipedia_anon_html)
     assert match, f"<img src> for {asset} not found in main page"
-    asset_url = match.group(1)
+    # Prod serves protocol-relative `//host/...` src; browsers resolve it but
+    # `requests` rejects it with MissingSchema. urljoin borrows the page scheme.
+    asset_url = urljoin(base_url, match.group(1))
     response = requests.get(asset_url, timeout=15)
     assert response.status_code == 200, (
         f"{asset} URL {asset_url} -> HTTP {response.status_code}"


### PR DESCRIPTION
## What

Makes the `infra/local-wiki/tests` integration suite run **green against prod** (`MACCABIPEDIA_LOCAL_URL=https://www.maccabipedia.co.il`), so the skin-deploy smoke check can exercise the whole suite instead of only `test_maccabipedia_scaffold.py`'s subset.

Two tests failed against prod for **local-only reasons** (not real skin bugs):

1. **`test_no_prod_url_leakage`** — asserts the prod domain is absent from the page. This is a *local-mirror* invariant (catch hardcoded prod URLs in dev). Against prod the page legitimately contains its own domain → fails by definition.
2. **`test_static_asset_loads[logo/powered-by]`** — `requests.get()` on the raw `<img src>`. Prod serves protocol-relative `//www.maccabipedia.co.il/...` URLs, which browsers resolve but `requests` rejects with `MissingSchema`. The asset is fine; the harness couldn't follow `//`.

## How

- `test_no_prod_url_leakage` → `pytest.skip` when the target host is the prod domain (`urlparse(base_url).netloc`).
- `test_static_asset_loads` → resolve the `src` via `urljoin(base_url, src)`, borrowing the page scheme. Absolute local URLs pass through unchanged, so local behaviour is preserved.

Both tests now take the existing `base_url` session fixture.

## Verification

```
$ MACCABIPEDIA_LOCAL_URL=https://www.maccabipedia.co.il uv run pytest -m integration infra/local-wiki/tests -q
38 passed, 22 skipped in 2.55s
```

The two target tests specifically: `test_no_prod_url_leakage` SKIPPED, `test_static_asset_loads[logo]` + `[powered-by]` PASSED.

Split out from #127 (skin deployment script + doc); the doc's "expected failures" caveat was removed in favour of this fix. Closes Trello 574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)