### PR TITLE
refactor(dev): unify page purging into shared bulk helper

### DIFF
--- a/packages/maccabipediabot/src/maccabipediabot/common/wiki_purge.py
+++ b/packages/maccabipediabot/src/maccabipediabot/common/wiki_purge.py
@@ -27,6 +27,8 @@ def purge_pages(
 
     Returns the number of unique pages submitted for purging.
     """
+    # Dedup + sort here (not just relying on purgepages' own set()) so the
+    # chunk boundaries below are deterministic and the returned count is accurate.
     titles = sorted({page if isinstance(page, str) else page.title() for page in pages})
     if not titles:
         return 0

--- a/packages/maccabipediabot/src/maccabipediabot/common/wiki_purge.py
+++ b/packages/maccabipediabot/src/maccabipediabot/common/wiki_purge.py
@@ -1,0 +1,47 @@
+import logging
+from collections.abc import Iterable
+
+import pywikibot as pw
+
+logger = logging.getLogger(__name__)
+
+# MediaWiki caps the number of titles accepted by a single purge request
+# (50 for regular accounts, 500 for bots). Stay at 50 so the bulk call works
+# regardless of the account's rights.
+_PURGE_CHUNK_SIZE = 50
+
+
+def purge_pages(
+    site: pw.Site,
+    pages: Iterable[str | pw.Page],
+    *,
+    dry_run: bool = False,
+    chunk_size: int = _PURGE_CHUNK_SIZE,
+) -> int:
+    """Purge pages in bulk so DPL/Cargo caches refresh.
+
+    Accepts page titles or ``Page`` objects, dedups them, and submits them to
+    the MediaWiki purge API with ``forcelinkupdate=True`` in chunks of
+    ``chunk_size``. This issues one HTTP request per chunk instead of one per
+    page (the per-page approach the football/volleyball bots used to carry).
+
+    Returns the number of unique pages submitted for purging.
+    """
+    titles = sorted({page if isinstance(page, str) else page.title() for page in pages})
+    if not titles:
+        return 0
+
+    if dry_run:
+        logger.info("[DRY-RUN] Would purge %d pages with forcelinkupdate=true", len(titles))
+        return len(titles)
+
+    logger.info("Purging %d pages with forcelinkupdate=true", len(titles))
+    for start in range(0, len(titles), chunk_size):
+        chunk = titles[start:start + chunk_size]
+        if not site.purgepages(chunk, forcelinkupdate=True):
+            # purgepages returns False when a title in the chunk wasn't
+            # purged/link-updated — almost always because the page doesn't
+            # exist yet, which is harmless here.
+            logger.info("Some of %d pages in this chunk were not purged (likely don't exist yet)", len(chunk))
+
+    return len(titles)

--- a/packages/maccabipediabot/src/maccabipediabot/football/gamesbot.py
+++ b/packages/maccabipediabot/src/maccabipediabot/football/gamesbot.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from typing import List
 
 from maccabipediabot.common.wiki_login import get_site
+from maccabipediabot.common.wiki_purge import purge_pages
 
 
 import mwparserfromhell
@@ -319,31 +320,6 @@ def collect_related_pages_from_game(game) -> set[str]:
     return pages_to_purge
 
 
-def purge_pages_batch(pages_to_purge: set[str]) -> None:
-    """Purge a batch of pages efficiently."""
-    if not pages_to_purge:
-        return
-
-    logging.info(f"Purging {len(pages_to_purge)} unique related pages...")
-    results = {"purged": 0, "skipped": 0, "failed": 0}
-
-    for page_name in sorted(pages_to_purge):
-        try:
-            page = pw.Page(site, page_name)
-            if page.exists():
-                logging.debug(f"Purging: {page_name}")
-                page.purge(forcelinkupdate=True)
-                results["purged"] += 1
-            else:
-                logging.debug(f"Page doesn't exist, skipping: {page_name}")
-                results["skipped"] += 1
-        except Exception as e:
-            logging.warning(f"Failed to purge {page_name}: {e}")
-            results["failed"] += 1
-
-    logging.info(f"Purge complete: {results['purged']} purged, {results['skipped']} skipped, {results['failed']} failed")
-
-
 def upload_games_to_maccabipedia(maccabi_games_to_add: MaccabiGamesStats):
     logging.info("")  # Empty line
 
@@ -369,7 +345,7 @@ def upload_games_to_maccabipedia(maccabi_games_to_add: MaccabiGamesStats):
 
     # Batch purge all collected pages at the end
     if SHOULD_SAVE and SHOULD_PURGE_RELATED_PAGES:
-        purge_pages_batch(all_pages_to_purge)
+        purge_pages(site, all_pages_to_purge)
 
     if SHOULD_CHECK_FOR_UPDATE_IN_EXISTING_PAGES:
         logging.info("Now handling existing games:")
@@ -382,7 +358,7 @@ def upload_games_to_maccabipedia(maccabi_games_to_add: MaccabiGamesStats):
 
         # Purge again if we updated existing games
         if SHOULD_SAVE and SHOULD_PURGE_RELATED_PAGES:
-            purge_pages_batch(all_pages_to_purge)
+            purge_pages(site, all_pages_to_purge)
     else:
         logging.info("Don't check for updates in existing pages")
 

--- a/packages/maccabipediabot/src/maccabipediabot/maintenance/sync_navigation_categories.py
+++ b/packages/maccabipediabot/src/maccabipediabot/maintenance/sync_navigation_categories.py
@@ -36,6 +36,7 @@ import pywikibot
 
 from maccabipediabot.common.logging_setup import setup_logging
 from maccabipediabot.common.wiki_login import get_site
+from maccabipediabot.common.wiki_purge import purge_pages
 
 logger = logging.getLogger(__name__)
 
@@ -126,25 +127,6 @@ def discover_matches(
             if sport_filter is not None and parsed.sport != sport_filter:
                 continue
             yield title, parsed
-
-
-def purge_pages(
-    site: pywikibot.Site, pages: list[pywikibot.Page], dry_run: bool
-) -> int:
-    """Purge pages with forcelinkupdate=true so DPL caches refresh.
-
-    Returns the number of pages submitted to purge.
-    """
-    if not pages:
-        return 0
-    if dry_run:
-        logger.info(
-            "[DRY-RUN] Would purge %d pages with forcelinkupdate=true", len(pages)
-        )
-        return len(pages)
-    logger.info("[PURGE] Purging %d pages with forcelinkupdate=true", len(pages))
-    site.purgepages(pages, forcelinkupdate=True)
-    return len(pages)
 
 
 def main(

--- a/packages/maccabipediabot/src/maccabipediabot/volleyball/gamesbot_volleyball.py
+++ b/packages/maccabipediabot/src/maccabipediabot/volleyball/gamesbot_volleyball.py
@@ -10,6 +10,7 @@ from maccabipediabot.common.logging_setup import setup_logging
 from maccabipediabot.common.page_names import build_volleyball_game_page_name
 from maccabipediabot.common.paths import volleyball_root
 from maccabipediabot.common.prettify_games_pages import prettify_game_page_main_template
+from maccabipediabot.common.wiki_purge import purge_pages
 from maccabipediabot.volleyball.volleyball_game import VolleyballGame
 
 import pywikibot as pw
@@ -198,31 +199,6 @@ def collect_related_pages_from_game(game: VolleyballGame) -> set[str]:
     return pages_to_purge
 
 
-def purge_pages_batch(pages_to_purge: set[str]) -> None:
-    """Purge a batch of pages efficiently."""
-    if not pages_to_purge:
-        return
-
-    logging.info(f"Purging {len(pages_to_purge)} unique related pages...")
-    results = {"purged": 0, "skipped": 0, "failed": 0}
-
-    for page_name in sorted(pages_to_purge):
-        try:
-            page = pw.Page(site, page_name)
-            if page.exists():
-                logging.debug(f"Purging: {page_name}")
-                page.purge(forcelinkupdate=True)
-                results["purged"] += 1
-            else:
-                logging.debug(f"Page doesn't exist, skipping: {page_name}")
-                results["skipped"] += 1
-        except Exception as e:
-            logging.warning(f"Failed to purge {page_name}: {e}")
-            results["failed"] += 1
-
-    logging.info(f"Purge complete: {results['purged']} purged, {results['skipped']} skipped, {results['failed']} failed")
-
-
 def create_or_update_game_page(volleyball_game: VolleyballGame, overwrite_existing_pages: bool = True):
     logging.info(f"create_or_update_game_page : {volleyball_game}")
 
@@ -275,7 +251,7 @@ def create_or_update_volleyball_game_pages(games_to_add: List[VolleyballGame]):
 
     # Batch purge all collected pages at the end
     if SHOULD_SAVE and SHOULD_PURGE_RELATED_PAGES:
-        purge_pages_batch(all_pages_to_purge)
+        purge_pages(site, all_pages_to_purge)
 
     logging.info("Finished handling existing games.")
 

--- a/packages/maccabipediabot/tests/common/test_wiki_purge.py
+++ b/packages/maccabipediabot/tests/common/test_wiki_purge.py
@@ -55,6 +55,16 @@ def test_chunks_respect_chunk_size():
     assert [len(titles) for titles, _ in site.calls] == [50, 50, 20]
 
 
+def test_returns_full_count_when_purgepages_reports_false():
+    # purgepages returns False when a title wasn't purged/link-updated (usually
+    # because it doesn't exist yet) — the helper should still report every
+    # submitted title and must not raise.
+    site = StubSite(return_value=False)
+    submitted = purge_pages(site, ["אבי כהן", "ערן זהבי"])
+    assert submitted == 2
+    assert len(site.calls) == 1
+
+
 def test_dry_run_submits_nothing():
     site = StubSite()
     submitted = purge_pages(site, ["אבי כהן", "ערן זהבי"], dry_run=True)

--- a/packages/maccabipediabot/tests/common/test_wiki_purge.py
+++ b/packages/maccabipediabot/tests/common/test_wiki_purge.py
@@ -1,0 +1,62 @@
+from maccabipediabot.common.wiki_purge import purge_pages
+
+
+class StubSite:
+    """Records every purgepages call so tests can assert on batching."""
+
+    def __init__(self, return_value: bool = True):
+        self.calls: list[tuple[list[str], dict]] = []
+        self._return_value = return_value
+
+    def purgepages(self, pages, **kwargs):
+        self.calls.append((list(pages), kwargs))
+        return self._return_value
+
+
+class StubPage:
+    """Minimal stand-in for a pywikibot Page (only .title() is used)."""
+
+    def __init__(self, title: str):
+        self._title = title
+
+    def title(self) -> str:
+        return self._title
+
+
+def test_empty_input_makes_no_call():
+    site = StubSite()
+    assert purge_pages(site, []) == 0
+    assert site.calls == []
+
+
+def test_dedups_and_sorts_titles():
+    site = StubSite()
+    submitted = purge_pages(site, ["מוטל'ה שפיגלר", "אבי כהן", "אבי כהן"])
+    assert submitted == 2
+    assert len(site.calls) == 1
+    titles, kwargs = site.calls[0]
+    assert titles == ["אבי כהן", "מוטל'ה שפיגלר"]
+    assert kwargs == {"forcelinkupdate": True}
+
+
+def test_page_objects_and_strings_dedup_by_title():
+    site = StubSite()
+    submitted = purge_pages(site, [StubPage("ערן זהבי"), "ערן זהבי", StubPage("טל ברודי")])
+    assert submitted == 2
+    titles, _ = site.calls[0]
+    assert titles == ["טל ברודי", "ערן זהבי"]
+
+
+def test_chunks_respect_chunk_size():
+    site = StubSite()
+    pages = [f"page-{index:03d}" for index in range(120)]
+    submitted = purge_pages(site, pages, chunk_size=50)
+    assert submitted == 120
+    assert [len(titles) for titles, _ in site.calls] == [50, 50, 20]
+
+
+def test_dry_run_submits_nothing():
+    site = StubSite()
+    submitted = purge_pages(site, ["אבי כהן", "ערן זהבי"], dry_run=True)
+    assert submitted == 2
+    assert site.calls == []


### PR DESCRIPTION
## What

Consolidates the three separate page-purge implementations into one shared
helper, `common/wiki_purge.purge_pages(site, pages, *, dry_run=False, chunk_size=50)`.

Before, there were three copies:
- `football/gamesbot.py` — `purge_pages_batch`, **one HTTP request per page** (with an `exists()` pre-check)
- `volleyball/gamesbot_volleyball.py` — a byte-identical copy, also per-page
- `maintenance/sync_navigation_categories.py` — already used the bulk `site.purgepages` API

The new helper accepts page titles **or** `Page` objects, dedups them, and submits
them via the bulk purge API (`forcelinkupdate=True`) in chunks of 50 (the API title
cap). All three call sites now route through it.

## Why

- **Speed** — football/volleyball previously fired one HTTP request per related page
  (often dozens after a game upload). Now it's one request per 50 pages.
- **Less duplication** — the football/volleyball copies are gone; the maintenance
  script's local copy is gone too.
- **Shared utils should be public** — the helper lives in `common/` instead of being
  re-implemented per script.

## Behavioral notes

- The per-page `exists()` check is dropped — purging a non-existent page is a harmless
  no-op via the bulk API. The granular `purged/skipped/failed` log line is replaced by a
  single submitted-count line (matching the reference `sync_navigation_categories` impl).
- The per-page `try/except Exception` is gone, so a genuine purge API error now
  propagates instead of being swallowed. Purging runs *after* pages are saved, so this
  surfaces real failures without risking data loss.

## Tests

- New `tests/common/test_wiki_purge.py` covering empty input, dedup+sort, mixed
  title/Page-object dedup, chunk boundaries, and dry-run.
- Full suite: `244 passed`.

Trello: https://trello.com/c/U5cO0UR2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
