### PR TITLE
fix(basketball): handle ליגת העל playoff games (game_type 16)

### DIFF
--- a/.claude/maccabipedia_structure_knowledge.md
+++ b/.claude/maccabipedia_structure_knowledge.md
@@ -161,6 +161,20 @@ Multiple players are joined with `,\n` (comma + newline). Both `|שחקנים מ
 - `זריקות/קליעות שתי נק` — free throw attempts/made (confusingly named "two-point throws")
 - `פאולים טכני` — optional, omit entirely if zero
 
+## 10b. Basketball Competition Codes & Playoff Naming (basket.co.il)
+
+The `games_all.json` feed tags each game with a numeric `game_type`, mapped in `translations._BASKET_GAME_TYPE`:
+
+| `game_type` | Competition (`מפעל`) |
+|---|---|
+| `5` | `ליגת העל` (regular season) |
+| `16` | `ליגת העל` (championship **playoffs** — round lives in `שלב במפעל`, not in `מפעל`) |
+| `34` | `הסופרקאפ הישראלי` |
+
+Unmapped `game_type` codes raise `RuntimeError` in `discover_games_latest_season` (intentional — don't silently lose a competition). When a new code appears (e.g. a future cup), add it to `_BASKET_GAME_TYPE`.
+
+**Playoff games:** `מפעל=ליגת העל` with the round in `שלב במפעל`, e.g. `רבע גמר - משחק 1`, `חצי גמר - משחק 2`, `גמר - משחק 3`. The page title uses only the competition: `כדורסל:DD-MM-YYYY מכבי תל אביב נגד <יריבה> - ליגת העל`. basket.co.il's raw header label (`- רבע הגמר משחק מספר N`) is normalized to this convention by `crawl_basket_co_il._normalize_fixture`.
+
 ## 11. Volleyball Player Stats (`|שחקנים מכבי=` / `|שחקנים יריבה=`)
 
 Volleyball game pages use template `משחק כדורעף`. Player data is a `::` delimited row per player:

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/crawl_basket_co_il.py
@@ -38,6 +38,27 @@ MACCABI_TEAM_NAME_ENG = "Maccabi Tel-Aviv"
 MAX_CONNECTIONS = 100
 
 
+# basket.co.il labels a playoff leg "- רבע הגמר משחק מספר 1"; the wiki convention
+# (see existing ליגת העל playoff pages) is "רבע גמר - משחק 1".
+_PLAYOFF_ROUND_NAMES = {
+    "רבע ה": "רבע גמר",
+    "חצי ה": "חצי גמר",
+    "ה": "גמר",
+}
+_PLAYOFF_FIXTURE_RE = re.compile(
+    r"^-?\s*(רבע ה|חצי ה|ה)גמר\s+משחק מספר\s+(\d+)\s*$"
+)
+
+
+def _normalize_fixture(fixture: str) -> str:
+    """Map a basket.co.il playoff leg to the wiki convention "<round> - משחק N".
+    Regular-season "מחזור N" (and any unrecognised label) is returned unchanged."""
+    match = _PLAYOFF_FIXTURE_RE.match(fixture)
+    if not match:
+        return fixture
+    return f"{_PLAYOFF_ROUND_NAMES[match.group(1)]} - משחק {match.group(2)}"
+
+
 def parse_game_page(html: str, partial_game: BasketballGame) -> BasketballGame:
     """Enrich a partially-built BasketballGame (from discovery) with per-game data.
 
@@ -97,7 +118,7 @@ def _parse_header(soup: BeautifulSoup) -> dict:
         if img and img.next_sibling:
             sibling_text = (img.next_sibling.get_text() if hasattr(img.next_sibling, "get_text")
                             else str(img.next_sibling))
-            fixture = sibling_text.strip().replace("סל", "").strip()
+            fixture = _normalize_fixture(sibling_text.strip().replace("סל", "").strip())
 
     h5 = container.select_one("h5")
     stadium = ""

--- a/packages/maccabipediabot/src/maccabipediabot/basketball/translations.py
+++ b/packages/maccabipediabot/src/maccabipediabot/basketball/translations.py
@@ -441,6 +441,7 @@ _PLAYER_NAME_NORMALIZE: dict[str, str] = {
 
 _BASKET_GAME_TYPE: dict[int, str] = {
     5: "ליגת העל",
+    16: "ליגת העל",          # ליגת העל playoff; the round (רבע גמר וכו') lives in the fixture
     34: "הסופרקאפ הישראלי",
 }
 

--- a/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
+++ b/packages/maccabipediabot/tests/basketball/test_crawl_basket_co_il.py
@@ -10,6 +10,8 @@ from maccabipediabot.basketball.basketball_game import BasketballGame
 from maccabipediabot.basketball._crawler_utils import write_unknown_teams_report
 from maccabipediabot.basketball.crawl_basket_co_il import (
     UnknownTeamNameError,
+    _normalize_fixture,
+    _parse_header,
     _parse_player_rows,
     discover_games_latest_season,
     parse_game_page,
@@ -95,6 +97,35 @@ def test_parse_player_rows_preserves_jersey_number(cell0, expected_number):
     players = _parse_player_rows(table)
     assert len(players) == 1
     assert players[0].number == expected_number
+
+
+@pytest.mark.parametrize("raw, expected", [
+    # basket.co.il playoff legs -> wiki convention "<round> - משחק N"
+    ("- רבע הגמר משחק מספר 1", "רבע גמר - משחק 1"),
+    ("- חצי הגמר משחק מספר 2", "חצי גמר - משחק 2"),
+    ("- הגמר משחק מספר 3", "גמר - משחק 3"),
+    # regular season and anything unrecognised pass through untouched
+    ("מחזור 26", "מחזור 26"),
+    ("", ""),
+])
+def test_normalize_fixture(raw, expected):
+    assert _normalize_fixture(raw) == expected
+
+
+def _header_html(h4_inner: str) -> str:
+    """Minimal #wrap_inner_3 carrying just the h4 fixture line."""
+    return (f'<div id="wrap_inner_3"><h4 class="he">{h4_inner}</h4>'
+            f'<h5>אולם, עיר</h5><h6></h6></div>')
+
+
+@pytest.mark.parametrize("h4_inner, expected_fixture", [
+    # mirrors the real basket.co.il h4: text "ליגת <logo> סל <fixture>"
+    ('ליגת <img src="x"/> סל מחזור 26', "מחזור 26"),
+    ('ליגת <img src="x"/> סל - רבע הגמר משחק מספר 1', "רבע גמר - משחק 1"),
+])
+def test_parse_header_normalizes_playoff_fixture(h4_inner, expected_fixture):
+    soup = BeautifulSoup(_header_html(h4_inner), "html.parser")
+    assert _parse_header(soup)["fixture"] == expected_fixture
 
 
 def test_parse_game_page_raises_when_header_missing():

--- a/packages/maccabipediabot/tests/basketball/test_translations.py
+++ b/packages/maccabipediabot/tests/basketball/test_translations.py
@@ -41,6 +41,7 @@ def test_normalize_player_name_strips_trailing_junior_suffix():
 
 @pytest.mark.parametrize("code, expected", [
     (5, "ליגת העל"),
+    (16, "ליגת העל"),          # ליגת העל playoff stage (round lives in the fixture)
     (34, "הסופרקאפ הישראלי"),
     (999, None),
 ])


### PR DESCRIPTION
## What

- Map basket.co.il `game_type=16` (ליגת העל playoff stage) to competition `ליגת העל` in `_BASKET_GAME_TYPE`.
- Normalize the basket.co.il playoff leg label (`- רבע הגמר משחק מספר N`) to the wiki convention (`רבע גמר - משחק N`) in the game-zone header parser. Regular-season `מחזור N` is unchanged.

## Why

basket.co.il marks league playoff games with `game_type=16`, which was not mapped. `discover_games_latest_season` raised `RuntimeError` ("unknown game_type") on every playoff game, so the bot could not upload any league-playoff game during the playoff window. The round is modelled in the fixture (`שלב במפעל`), matching how existing playoff pages on the wiki are structured (`מפעל=ליגת העל`, `שלב במפעל=רבע גמר - משחק N`).

## Tests

- `test_basket_co_il_competition_name` covers `game_type=16 → ליגת העל`.
- `test_normalize_fixture` and `test_parse_header_normalizes_playoff_fixture` cover the playoff round normalization and that regular-season / unrecognised labels pass through untouched.
- Full `maccabipediabot` suite: 246 passed.
- Verified end-to-end against the live game-zone page: the full discover→parse pipeline now yields `מפעל=ליגת העל`, `שלב במפעל=רבע גמר - משחק 1`, and the correct page name (no crash on `game_type=16`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)