### PR TITLE
feat(dev): add context-friendly Trello read scripts

### DIFF
--- a/.claude/scripts/trello_card.py
+++ b/.claude/scripts/trello_card.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Print a trimmed view of one Trello card, resolved by its short number.
+
+Context-friendly replacement for the trello MCP's get_card. Full JSON (including
+all checklist items) is saved to .claude/tmp/. See .claude/trello.md.
+
+Usage:
+    uv run python .claude/scripts/trello_card.py <cardNumber>
+"""
+import sys
+
+from trello_common import format_labels, load_creds, save_full, trello_get
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: trello_card.py <cardNumber>")
+    number = sys.argv[1]
+    _, _, board_id = load_creds()
+
+    card = trello_get(
+        f"boards/{board_id}/cards/{number}",
+        {"fields": "name,labels,desc,url,idList", "checklists": "all"},
+    )
+    out_path = save_full(f"trello_card_{number}", card)
+
+    list_name = "?"
+    if card.get("idList"):
+        list_name = trello_get(f"lists/{card['idList']}", {"fields": "name"})["name"]
+    print(f"#{number}  {card['name']}  [{format_labels(card)}]")
+    print(f"list: {list_name}")
+    print(f"url:  {card.get('url', '')}")
+    if card.get("desc"):
+        print(f"\ndesc:\n{card['desc']}")
+    for checklist in card.get("checklists", []):
+        print(f"\nchecklist: {checklist['name']}")
+        for item in checklist.get("checkItems", []):
+            mark = "x" if item["state"] == "complete" else " "
+            print(f"  [{mark}] {item['name']}")
+    print(f"\nfull JSON saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/trello_common.py
+++ b/.claude/scripts/trello_common.py
@@ -9,6 +9,7 @@ redirected to a file. A curl can. So every read here saves the full JSON to
 """
 import json
 import pathlib
+import urllib.error
 import urllib.parse
 import urllib.request
 
@@ -29,8 +30,21 @@ def trello_get(path, extra_params=None):
     if extra_params:
         params.update(extra_params)
     url = f"https://api.trello.com/1/{path}?{urllib.parse.urlencode(params)}"
-    with urllib.request.urlopen(url, timeout=30) as response:
-        return json.load(response)
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            content_type = response.headers.get("Content-Type", "")
+            body = response.read()
+    except urllib.error.HTTPError as error:
+        # error.url / error.filename carry the secret-bearing URL (key+token);
+        # never surface them — report only the status and the safe path.
+        raise RuntimeError(
+            f"Trello GET /{path} failed: HTTP {error.code} {error.reason}"
+        ) from None
+    if "application/json" not in content_type:
+        raise RuntimeError(
+            f"Trello GET /{path} returned non-JSON ({content_type or 'unknown'})"
+        )
+    return json.loads(body)
 
 
 def save_full(name, data):
@@ -42,4 +56,6 @@ def save_full(name, data):
 
 
 def format_labels(card):
-    return ", ".join(label["name"] for label in card.get("labels", []) if label["name"])
+    return ", ".join(
+        label.get("name") for label in card.get("labels", []) if label.get("name")
+    )

--- a/.claude/scripts/trello_common.py
+++ b/.claude/scripts/trello_common.py
@@ -1,0 +1,45 @@
+"""Shared helpers for the trello_*.py read scripts.
+
+Reads = scripts (this family); writes = the trello MCP. See .claude/trello.md.
+
+These scripts exist because the third-party trello MCP's read tools have no field
+filtering: they dump the full ~40K-char card JSON, and MCP output cannot be
+redirected to a file. A curl can. So every read here saves the full JSON to
+.claude/tmp/ and prints only a trimmed view, keeping the model's context small.
+"""
+import json
+import pathlib
+import urllib.parse
+import urllib.request
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+TMP_DIR = REPO / ".claude" / "tmp"
+
+
+def load_creds():
+    config = json.loads((REPO / ".mcp.json").read_text())
+    env = config["mcpServers"]["trello"]["env"]
+    return env["TRELLO_API_KEY"], env["TRELLO_TOKEN"], env["TRELLO_BOARD_ID"]
+
+
+def trello_get(path, extra_params=None):
+    """GET https://api.trello.com/1/<path> with auth, returning parsed JSON."""
+    api_key, token, _ = load_creds()
+    params = {"key": api_key, "token": token}
+    if extra_params:
+        params.update(extra_params)
+    url = f"https://api.trello.com/1/{path}?{urllib.parse.urlencode(params)}"
+    with urllib.request.urlopen(url, timeout=30) as response:
+        return json.load(response)
+
+
+def save_full(name, data):
+    """Save full JSON to .claude/tmp/<name>.json and return the path."""
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = TMP_DIR / f"{name}.json"
+    out_path.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+    return out_path
+
+
+def format_labels(card):
+    return ", ".join(label["name"] for label in card.get("labels", []) if label["name"])

--- a/.claude/scripts/trello_list.py
+++ b/.claude/scripts/trello_list.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Print a trimmed view of a Trello list's cards (idShort, name, labels).
+
+Context-friendly replacement for the trello MCP's get_cards_by_list_id (no field
+filtering, banned in CLAUDE.md). Full JSON is saved to .claude/tmp/. See
+.claude/trello.md.
+
+Usage:
+    uv run python .claude/scripts/trello_list.py <listId>
+"""
+import sys
+
+from trello_common import format_labels, save_full, trello_get
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: trello_list.py <listId>")
+    list_id = sys.argv[1]
+
+    cards = trello_get(
+        f"lists/{list_id}/cards", {"fields": "name,labels,idShort"}
+    )
+    out_path = save_full(f"trello_list_{list_id}", cards)
+
+    for card in cards:
+        print(f"#{card['idShort']}  {card['name']}  [{format_labels(card)}]")
+    print(f"\n{len(cards)} cards — full JSON saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/trello.md
+++ b/.claude/trello.md
@@ -1,0 +1,46 @@
+# Talking to Trello
+
+The board is **MaccabiPedia** (`https://trello.com/b/n9Zz1CSL`). Credentials
+(`TRELLO_API_KEY`, `TRELLO_TOKEN`, `TRELLO_BOARD_ID`) live in `.mcp.json` under
+`mcpServers.trello.env`.
+
+## The rule: reads = scripts, writes = MCP
+
+| Operation | Use | Why |
+|-----------|-----|-----|
+| **Read** a list, a card, the board | `.claude/scripts/trello_*.py` | MCP read tools have no field filtering and dump the full ~40K-char card JSON. MCP output **cannot be redirected to a file** — it always lands in context. A script `curl`s, saves full JSON to `.claude/tmp/`, and prints only a trimmed view. |
+| **Write** — add/move/update/archive a card, add a comment or checklist item | trello MCP (`mcp__trello__*`) | Write responses are small, and the MCP handles auth + board context. No reason to reimplement. |
+
+This is why `get_cards_by_list_id` and `get_card` are effectively banned for reads
+(see CLAUDE.md §6).
+
+## Read scripts
+
+All share `trello_common.py` (cred loading, authenticated GET, save-to-tmp,
+label formatting). Run with `uv run`:
+
+```
+uv run python .claude/scripts/trello_list.py <listId>     # cards in a list: idShort, name, labels
+uv run python .claude/scripts/trello_card.py <cardNumber> # one card: name, labels, list, url, desc, checklists
+```
+
+Each prints a trimmed view and saves the full JSON to
+`.claude/tmp/trello_list_<id>.json` / `trello_card_<number>.json` for when you
+need a field the trimmed view dropped.
+
+## Finding IDs
+
+- **List IDs** — `mcp__trello__get_lists` returns all lists with their IDs (small
+  response, safe to call). Current board lists: Waiting, Backlog, **Next Up**,
+  In Progress, Done, For the far future, Road map.
+- **Card numbers** — the `#NNN` shown by `trello_list.py`, or the number in a card
+  URL (`/c/<hash>/<number>-...`). `trello_card.py` resolves a card by number via
+  `/boards/{boardId}/cards/{number}`.
+
+## Gotchas (also in memory)
+
+- `move_card` needs `boardId` passed explicitly — the "default" fallback returns 400.
+- The `list=true` embed param is **not** honored on the board-scoped card endpoint;
+  request `idList` and resolve the list name separately (what `trello_card.py` does).
+- If the MCP itself is down, the read scripts still work (pure REST); for writes,
+  fall back to the Trello REST API with the same `.mcp.json` creds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ Every tool call result stays in context forever. Keep all outputs small:
 - **Subagent results**: any Agent call should write its output to `.claude/tmp/` and return a brief summary — not the full analysis inline.
 - **Write vs Edit**: never use Write to modify an existing file — Edit sends only the diff. Only use Write for new files, and avoid writing files larger than ~100 lines in one shot; break them up.
 - **Bash outputs**: if a script produces more than ~50 lines, redirect verbose output to a temp file and print only the final result.
-- **Trello MCP**: never call `get_cards_by_list_id` — it returns full JSON for every card (~40K chars). Use `get_card` on specific card IDs only.
+- **Trello reads vs writes**: writes use the MCP (`add_card`, `add_comment`, `move_card`, …); reads use the `.claude/scripts/trello_*.py` helpers, never the MCP read tools. MCP output can't be redirected to a file, so `get_cards_by_list_id`/`get_card` dump full card JSON (~40K chars) straight into context. The scripts save full JSON to `.claude/tmp/` and print a trimmed view. See `.claude/trello.md`.
 - **Knowledge files** (`.claude/*.md`): never Read the whole file. Use Grep to find the relevant section, then Read only those lines.
 
 ## 7. Reference Files
@@ -94,3 +94,4 @@ Every tool call result stays in context forever. Keep all outputs small:
 - `.claude/maccabistats_knowledge.md` — maccabistats Python package API reference
 - `.claude/maccabipedia_youtube_channel.md` — MaccabiPedia YouTube channel conventions + Google Drive backup layout (used by `restore_deleted_football_video`)
 - Prod deploys → the `deploy-skin` and `deploy-localsettings` skills (`.claude/skills/`). Skin = `skins/Maccabipedia/` via snapshot + manual FileZilla upload; LocalSettings = `infra/local-wiki/config/LocalSettings.shared.php` only (never `env.prod.php`). FTP creds in `infra/local-wiki/.env`.
+- `.claude/trello.md` — Trello convention: reads via `.claude/scripts/trello_*.py` (save full JSON to tmp, print trimmed), writes via the MCP; why; how to find list/board IDs


### PR DESCRIPTION
## What

Adds context-friendly Trello **read** scripts and documents a clear convention: **reads via scripts, writes via the MCP.**

- `.claude/scripts/trello_common.py` — shared cred loading, authenticated GET, save-to-tmp, label formatting
- `.claude/scripts/trello_list.py <listId>` — cards in a list (idShort, name, labels)
- `.claude/scripts/trello_card.py <number>` — one card (name, labels, list, url, desc, checklists)
- `.claude/trello.md` — the convention, ID lookup, gotchas
- `CLAUDE.md` — §6 rule updated + §7 reference entry

## Why

The third-party trello MCP (`@delorenj/mcp-server-trello`) read tools have **no field filtering** — `get_cards_by_list_id` / `get_card` return the full ~40K-char card JSON. Crucially, **MCP tool output can't be redirected to a file**; it always lands in the model's context. A `curl` can. So each script saves the full JSON to `.claude/tmp/` and prints only a trimmed view, keeping context small while preserving the complete data on disk.

Writes (`add_card`, `move_card`, `add_comment`, …) keep using the MCP — small responses, and it handles auth/board context.

## Test

Both scripts run against the live board:

```
uv run python .claude/scripts/trello_list.py 6641215d3e12b0b1b904b103   # Next Up: 4 cards
uv run python .claude/scripts/trello_card.py 527                        # resolves card + list name
```

Stdlib-only tooling under `.claude/` — no change to the Python package, so the package test/type suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
