### PR TITLE
docs(dev): per-season basketball ticket category + page convention

### DIFF
--- a/.claude/maccabipedia_structure_knowledge.md
+++ b/.claude/maccabipedia_structure_knowledge.md
@@ -108,6 +108,8 @@ Hebrew redirect syntax: `#הפניה [[Target_Page_Name]]`
 
 **Tickets** (`File:` pages):
 - Basketball: `{{תיוג כרטיס משחק כדורסל|משחק=PAGE_NAME}}`
+- Per-season category auto-assigned: `קטגוריה:כרטיסי משחק כדורסל מעונת YYYY/YY`
+- Each season with tickets has a dedicated page `כרטיסי משחק כדורסל YYYY/YY` containing just `{{כרטיסי עונה|ענף=כדורסל|עונה=YYYY/YY}}` — the template renders the tabbed visualization (league/cup/europe/other) by querying the per-season category. After uploading tickets for a new season, create this page if missing.
 
 **Posters** (`File:` pages):
 - Basketball: `{{תיוג כרזת כדורסל|משחק=PAGE_NAME}}`


### PR DESCRIPTION
## What

Documents the per-season basketball **ticket** convention in `.claude/maccabipedia_structure_knowledge.md`:

- The per-season category (`קטגוריה:כרטיסי משחק כדורסל מעונת YYYY/YY`) auto-assigned to ticket file pages.
- The dedicated per-season page (`כרטיסי משחק כדורסל YYYY/YY`) that wraps `{{כרטיסי עונה|ענף=כדורסל|עונה=YYYY/YY}}` to render the tabbed visualization, and the reminder to create it for a new season after uploading tickets.

## Why

This convention was previously undocumented. It was salvaged from an abandoned worktree during a worktree/branch cleanup so the knowledge isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
