### PR TITLE
docs(dev): document category sort keys for file uploads

### DIFF
--- a/.claude/maccabipedia_structure_knowledge.md
+++ b/.claude/maccabipedia_structure_knowledge.md
@@ -119,6 +119,11 @@ Hebrew redirect syntax: `#הפניה [[Target_Page_Name]]`
 **Newspapers** (`File:` pages, template `{{תיוג עיתונים}}`):
 - File naming: `{שם_עיתון}_{תאריך_המשחק}_{שם_היריבה}_{מספר}_{(תאריך_פרסום)}`
 
+**Category sort keys (every `File:` upload):**
+- A file sorts within its category by its **page title** unless given a sort key — `[[קטגוריה:X|sortkey]]`. Before deciding, **always check how existing similar uploads in the same category sort and match them** — staying consistent with the collection matters more than any general rule.
+- The common default is a **year** key (e.g. a season's ending year), but not always — some collections sort by date, opponent, or another field. So don't assume: confirm against the siblings, then set the matching key or consciously accept the default title-order.
+- Example: basketball season team photos (`כדורסל - תמונה קבוצתית YYYY-YY.jpg`, category `כדורסל/תמונות קבוצתיות`) use the season's **ending year** (`2010/11 → |2011`).
+
 ## 8. Non-Game Entities
 
 **Fan Songs** (`שיר:` namespace, template `{{שיר}}`):


### PR DESCRIPTION
## What
Adds a general convention to `.claude/maccabipedia_structure_knowledge.md` (§7 Game Media Files): on **every** categorized `File:` upload, deliberately decide the category sort key — set it whenever the filename wouldn't sort sensibly on its own (descriptive Hebrew names, `IMG_####`, mixed date/year formats), or consciously confirm the default title-order is correct.

Includes the basketball season team-photo case as the concrete example (ending-year key, `2010/11 → |2011`).

## Why
The team-photo sort-key convention was only captured in local Claude memory, which isn't shared with other developers (or their Claudes). Moving it into the committed structure-knowledge reference makes it apply team-wide, and generalizes it from team-photos to all file uploads. CLAUDE.md was deliberately avoided to keep the always-loaded global guide lean — this is reference material read on demand during wiki work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)